### PR TITLE
Manage GIL state in libzfs iterators

### DIFF
--- a/src/py_zfs_iter.c
+++ b/src/py_zfs_iter.c
@@ -1,5 +1,41 @@
 #include "py_zfs_iter.h"
 
+/*
+ * Implementation of python wrappers of libzfs iterators.
+ *
+ * py_iter_filesystems() should be used as a prototype for writing
+ * new iterators.
+ */
+
+
+/*
+ * Macros for toggling GIL within an iterator
+ * Application will dump core if python method called without GIL held.
+ */
+#define ITER_ALLOW_THREADS(state) { state->_save = PyEval_SaveThread(); }
+#define ITER_END_ALLOW_THREADS(state) {PyEval_RestoreThread(state->_save); }
+
+/**
+ * @brief Common callback function
+ *
+ * This callback function should be be called from within zfs_iter_f functions
+ * to call the requried python method specified by python API caller.
+ *
+ * NOTE: currently this function is called while the GIL is held. We can
+ * refactor if-needed, but since it's primarily a wrapper around calling a
+ * python function, GIL is generally needed here.
+ *
+ * @param[in] new_hdl	ZFSDataset, ZFSSnapshot, etc object to be passed as
+ *     as argument to python callback
+ *
+ * @param[in] state	py_zfs iterator state structure
+ *
+ * @return		int - either:
+ *			(0) Continue iteration,
+ *			(-1) ZFS iterator error,
+ *			(-2) Stop iteration,
+ *			(-3) Error from callback function
+ */
 static int
 common_callback(PyObject *new_hdl, py_iter_state_t *state)
 {
@@ -21,6 +57,7 @@ common_callback(PyObject *new_hdl, py_iter_state_t *state)
 	 */
 	PY_ZFS_LOCK(state->pylibzfsp);
 
+	// Deallocate and free handle if callback didn't increment it
 	Py_DECREF(new_hdl);
 	if (result == NULL) {
 		// Exception raised
@@ -37,6 +74,7 @@ common_callback(PyObject *new_hdl, py_iter_state_t *state)
 		return ITER_RESULT_STOP;
 	}
 
+	// We're done with the result and so we should free it
 	Py_DECREF(result);
 
 	PyErr_SetString(PyExc_TypeError,
@@ -48,18 +86,27 @@ common_callback(PyObject *new_hdl, py_iter_state_t *state)
 static int
 filesystem_callback(zfs_handle_t *zhp, void *private)
 {
-	int result;
+	int result = ITER_RESULT_ERROR;
 	py_iter_state_t *state = (py_iter_state_t *)private;
 	py_zfs_dataset_t *new_ds = NULL;
 
+	// re-enable GIL because we're creating a new python
+	// object and then calling the callback function.
+	ITER_END_ALLOW_THREADS(state);
+
 	new_ds = init_zfs_dataset(state->pylibzfsp, zhp);
 	if (new_ds == NULL) {
+		// we only explicitly zfs_close() in error
+		// path because new_ds owns it afterwards and
+		// will close in dealloc
 		zfs_close(zhp);
-		return ITER_RESULT_ERROR;
+		goto out;
 	}
 
 	result = common_callback((PyObject *)new_ds, state);
-	zfs_close(zhp);
+out:
+	// drop GIL because we're going back to iterating in ZFS
+	ITER_ALLOW_THREADS(state);
 	return result;
 }
 
@@ -67,17 +114,19 @@ filesystem_callback(zfs_handle_t *zhp, void *private)
 static int
 snapshot_callback(zfs_handle_t *zhp, void *private)
 {
-	int result;
+	int result = ITER_RESULT_ERROR;
 	py_iter_state_t *state = (py_iter_state_t *)private;
 	py_zfs_snapshot_t *new_snap = NULL;
 
 	new_snap = init_zfs_snapshot(state->pylibzfsp, zhp);
 	if (new_snap == NULL) {
-		return ITER_RESULT_ERROR;
+		zfs_close(zhp);
+		goto out;
 	}
 
 	result = common_callback((PyObject *)new_ds, state);
-	zfs_close(zhp);
+out:
+	ITER_ALLOW_THREADS(state);
 	return result;
 }
 
@@ -89,6 +138,7 @@ py_iter_filesystems(py_iter_state_t *state)
 	int iter_ret;
 	py_zfs_error_t zfs_err;
 
+	ITER_ALLOW_THREADS(state);
 	PY_ZFS_LOCK(state->pylibzfsp);
 
 	iter_ret = zfs_iter_filesystems_v2(state->target,
@@ -96,10 +146,15 @@ py_iter_filesystems(py_iter_state_t *state)
 					   filesystem_callback,
 					   (void *)state);
 	if (iter_ret == ITER_RESULT_IOCTL_ERROR) {
-		set_exc_from_libzfs(&zfs_err, "zfs_iter_filesystems_v2() failed");
+		py_get_zfs_error(state->pylibzfsp->lzh, &zfs_err);
 	}
 
 	PY_ZFS_UNLOCK(state->pylibzfsp);
+	ITER_END_ALLOW_THREADS(state);
+
+	if (iter_ret == ITER_RESULT_IOCTL_ERROR) {
+		set_exc_from_libzfs(&zfs_err, "zfs_iter_filesystems_v2() failed");
+	}
 
 	return iter_ret;
 }
@@ -113,6 +168,7 @@ py_iter_snapshots(py_iter_state_t *state)
 	py_zfs_error_t zfs_err;
 	iter_conf_snapshot_t conf = state->iter_config.snapshot;
 
+	ITER_ALLOW_THREADS(state);
 	PY_ZFS_LOCK(state->pylibzfsp);
 
 	if (conf->sorted) {
@@ -131,10 +187,15 @@ py_iter_snapshots(py_iter_state_t *state)
 						 conf.max_txg);
 	}
 	if (iter_ret == ITER_RESULT_IOCTL_ERROR) {
-		set_exc_from_libzfs(&zfs_err, "zfs_iter_filesystems_v2() failed");
+		py_get_zfs_error(state->pylibzfsp->lzh, &zfs_err);
 	}
 
 	PY_ZFS_UNLOCK(state->pylibzfsp);
+	ITER_END_ALLOW_THREADS(state);
+
+	if (iter_ret == ITER_RESULT_IOCTL_ERROR) {
+		set_exc_from_libzfs(&zfs_err, "zfs_iter_filesystems_v2() failed");
+	}
 
 	return iter_ret;
 }

--- a/src/py_zfs_iter.h
+++ b/src/py_zfs_iter.h
@@ -34,12 +34,32 @@ union iter_config {
 	iter_conf_bookmark_t bookmark;
 };
 
+/*
+ * Common iter state for all ZFS iterators
+ *
+ * pylibzfsp: pointer to underlying libzfs object. This is required in order
+ *     to create ZFS objects and do proper reference counting as well as
+ *     locking.
+ *
+ * target: libzfs_handle_t handle to iterate.
+ *
+ * callback_fn: python callback function to be called in the zfs_iter_f
+ *     callback in py_zfs_iter.c
+ *
+ * private_data: private data provided by python method caller. May be NULL.
+ *     if non-null then is added as an argument to the callback.
+ *
+ * iter_config: iterator-specific configuration options
+ *
+ * _save - saved thread state to allow toggling GIL as part of iteration.
+ */
 typedef struct {
 	py_zfs_t *pylibzfsp;
 	zfs_handle_t *target;
 	PyObject *callback_fn;
 	PyObject *private_data;
 	union iter_config iter_config;
+	PyThreadState *_save;
 } py_iter_state_t;
 
 extern int py_iter_filesystems(py_iter_state_t *state);


### PR DESCRIPTION
This commit adds pointer to stored thread state in pylibzfs iterator state struct. Two macros are also added to simplify toggling GIL in iterators and comments are added to clarify how to write a new iterator.