### PR TITLE
properly flag simple handle

### DIFF
--- a/src/py_zfs_iter.c
+++ b/src/py_zfs_iter.c
@@ -103,6 +103,10 @@ filesystem_callback(zfs_handle_t *zhp, void *private)
 		goto out;
 	}
 
+	if (state->iter_config.filesystem.flags & ZFS_ITER_SIMPLE) {
+		new_ds->rsrc.is_simple = B_TRUE;
+	}
+
 	result = common_callback((PyObject *)new_ds, state);
 out:
 	// drop GIL because we're going back to iterating in ZFS


### PR DESCRIPTION
Set resource is_simple if iterator was called with flag to create simple handles. This properly indicates that ZFSDataset object will not have full properties initialized.