### PR TITLE
NAS-136156 / 25.10 / Use zfs_prop_to_name for ZFSProperty names

### DIFF
--- a/src/libzfs/py_zfs_enum.c
+++ b/src/libzfs/py_zfs_enum.c
@@ -47,6 +47,7 @@ PyObject *zfs_prop_table_to_dict(void)
 
 	for (i=0; i < ARRAY_SIZE(zfs_prop_table); i++) {
 		PyObject *val = NULL;
+		PyObject *key = NULL;
 
 		/*
 		 * For now exclude properties that aren't
@@ -61,10 +62,22 @@ PyObject *zfs_prop_table_to_dict(void)
 		if (val == NULL)
 			goto fail;
 
-		err = PyDict_SetItemString(dict_out,
-					   zfs_prop_table[i].name,
-					   val);
+		key = PyUnicode_FromString(zfs_prop_to_name(zfs_prop_table[i].prop));
+		if (key == NULL) {
+			Py_DECREF(val);
+			goto fail;
+		}
+
+		PyObject *uppercase_key = PyObject_CallMethod(key, "upper", NULL);
+		Py_DECREF(key);
+		if (uppercase_key == NULL) {
+			Py_DECREF(val);
+			goto fail;
+		}
+
+		err = PyDict_SetItem(dict_out, uppercase_key, val);
 		Py_DECREF(val);
+		Py_DECREF(uppercase_key);
 		if (err)
 			goto fail;
 	}


### PR DESCRIPTION
The hand-rolled, statically typed zfs_prop_table that we write is prone to subtle mismatches with zfs's upstream tables. For a concrete example, the `ENCRYPTION_ROOT` name does not match the property name upstream. It's `ENCRYPTIONROOT`.

Instead of depending on our statically typed strings, use the `zfs_prop_to_name` function to populate the ZFSProperty enum names.