### PR TITLE
NAS-140536 / 26.0.0-BETA.2 / Improve some refcounting usage in truenas_pylibzfs (by anodos325)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,9 @@ examples/                   — usage examples
 
 - Declare variables at the head of functions (C89 style).
 - NULL-initialize pointers at declaration: `nvlist_t *nvl = NULL;`
+- Use `Py_SETREF(op, newval)` instead of `Py_DECREF(op); op = newval;`.
+  Use `Py_XSETREF` when `op` may be NULL. Use `Py_CLEAR(op)` instead of
+  `Py_DECREF(op); op = NULL;`.
 - No column-alignment spacing for struct members or other constructs.
 - Header guards use `#ifndef _FOO_H` / `#define _FOO_H` / `#endif` — not `#pragma once`.
 - Docstrings belong in `py_zfs_core_module.c` as `PyDoc_STRVAR()`, not in implementation files.

--- a/src/common/nvlist_utils.c
+++ b/src/common/nvlist_utils.c
@@ -238,8 +238,7 @@ nvlist_t *py_zfsprops_dict_to_nvlist(pylibzfs_state_t *state,
 			pyval = PyDict_GetItem(value, pykey);
 			if (pyval == NULL) {
 				/* raw key wasn't present, try with "value" */
-				Py_DECREF(pykey);
-				pykey = PyUnicode_FromString("value");
+				Py_SETREF(pykey, PyUnicode_FromString("value"));
 				if (pykey == NULL) {
 					fnvlist_free(nvl);
 					return NULL;

--- a/src/libzfs/py_zfs_pool.c
+++ b/src/libzfs/py_zfs_pool.c
@@ -703,8 +703,7 @@ PyObject *py_zfs_pool_get_features(PyObject *self,
 					Py_XDECREF(guid_str);
 					Py_XDECREF(desc_str);
 					Py_XDECREF(state_str);
-					Py_DECREF(entry);
-					entry = NULL;
+					Py_CLEAR(entry);
 				} else {
 					PyStructSequence_SetItem(entry,
 					    ZPOOL_FEAT_GUID_IDX, guid_str);

--- a/src/libzfs/py_zfs_pool_prop.c
+++ b/src/libzfs/py_zfs_pool_prop.c
@@ -178,8 +178,7 @@ PyObject *py_zpool_get_one_prop(pylibzfs_state_t *state,
 			value = Py_NewRef(raw);
 		} else if (pend != (propbuf + strlen(propbuf))) {
 			/* Partial parse — use string */
-			Py_DECREF(value);
-			value = Py_NewRef(raw);
+			Py_SETREF(value, Py_NewRef(raw));
 		}
 	} else {
 		/* PROP_TYPE_STRING or PROP_TYPE_INDEX: use raw string */


### PR DESCRIPTION
This commit changes a few reference counting patterns to more closely line up with upstream cpython standards. CLAUDE.md is also updated to encourage automated tools to follow standards.

Original PR: https://github.com/truenas/truenas_pylibzfs/pull/223
