### PR TITLE
libzfs: fix NULL dereference in snapshot clone with properties

### DIFF
--- a/src/libzfs/py_zfs_snapshot.c
+++ b/src/libzfs/py_zfs_snapshot.c
@@ -158,6 +158,7 @@ PyObject *py_zfs_snapshot_clone(PyObject *self,	PyObject *args, PyObject *kwargs
 	}
 
 	if (pyprops) {
+		state = py_get_module_state(ds->rsrc.obj.pylibzfsp);
 		nvl = py_zfsprops_to_nvlist(state,
 					    pyprops,
 					    ds->rsrc.obj.ctype,


### PR DESCRIPTION
## Summary
- Initialize `state` via `py_get_module_state()` before passing it to `py_zfsprops_to_nvlist()` in `py_zfs_snapshot_clone()`
- Without this, calling `snapshot.clone(name="x", properties={...})` dereferences a NULL pointer