### PR TITLE
NAS-140638 / 26.0.0-BETA.2 / Add extension to retrieve module kstats (by anodos325)

### DIFF
--- a/.github/workflows/scripts/qemu-4-test.sh
+++ b/.github/workflows/scripts/qemu-4-test.sh
@@ -69,13 +69,13 @@ echo "=========================================="
 cd /home/debian/truenas_pylibzfs
 
 # Check stubs are internally self-consistent (catches phantom names in __all__, bad imports, etc.)
-echo "Running mypy on stubs..."
+echo "Running mypy on stubs/..."
 python3 -m mypy stubs/
 MYPY_EXIT=$?
 
 # Check that typed callers use the stubs correctly (catches signature mismatches
 # that stubtest cannot detect, e.g. wrong container type for holds arguments).
-echo "Running mypy on type_checks..."
+echo "Running mypy on tests/type_checks/..."
 python3 -m mypy tests/type_checks/
 MYPY_TYPE_CHECKS_EXIT=$?
 
@@ -86,10 +86,10 @@ MYPY_TYPE_CHECKS_EXIT=$?
 # `from truenas_pylibzfs import lzc` works fine.  stubtest uses
 # importlib.import_module() internally, so pre-registering the
 # submodules in sys.modules lets stubtest find and check them.
-echo "Running stubtest..."
+echo "Running stubtest for truenas_pylibzfs..."
 python3 -c "
 import truenas_pylibzfs, sys
-for name in ('lzc', 'libzfs_types', 'property_sets'):
+for name in ('lzc', 'libzfs_types', 'property_sets', 'kstat'):
     sys.modules['truenas_pylibzfs.' + name] = getattr(truenas_pylibzfs, name)
 from mypy.stubtest import main
 sys.argv = ['stubtest', 'truenas_pylibzfs']
@@ -97,7 +97,7 @@ sys.exit(main())
 "
 STUBTEST_EXIT=$?
 
-if [ $MYPY_EXIT -ne 0 ] || [ $STUBTEST_EXIT -ne 0 ] || [ $MYPY_TYPE_CHECKS_EXIT -ne 0 ]; then
+if [ $MYPY_EXIT -ne 0 ] || [ $MYPY_TYPE_CHECKS_EXIT -ne 0 ] || [ $STUBTEST_EXIT -ne 0 ]; then
     echo "ERROR: Stub checks failed"
     exit 1
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,20 @@ public API of the C extension for IDEs and type checkers.
 updates are purely documentation of the existing C API — if the C API needs to
 change, that is a separate task and must be done explicitly.
 
+### Keeping docstrings in sync
+
+`PyDoc_STRVAR` definitions in C module files and attribute/method docstrings in
+`.pyi` stubs describe the same API from two angles. Keep them consistent:
+
+- When adding or changing a `PyDoc_STRVAR` for a method or field, update the
+  corresponding stub docstring to match (and vice versa).
+- The C docstring is the authoritative source of truth for runtime `help()`
+  output; the stub docstring is what IDE hover tooltips display. Both should
+  carry the same essential description.
+- Stub docstrings should be user-facing prose — avoid exposing internal
+  implementation details (C type names, source file paths, kstat type codes,
+  etc.) that are not meaningful to a Python caller.
+
 ## Testing
 
 Tests use pytest and require a running system with ZFS support. Fixtures in

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # truenas_pylibzfs
 
-Python C extension providing bindings to libzfs and libzfs_core for TrueNAS. Exposes three modules:
+Python C extension providing bindings to libzfs and libzfs_core for TrueNAS, including a submodule for reading ZFS kernel statistics. Exposes four submodules:
 
 - **`truenas_pylibzfs`** — high-level libzfs wrapper (pools, datasets, volumes, snapshots, encryption, properties, events)
 - **`truenas_pylibzfs.lzc`** — low-level libzfs_core wrapper (atomic send/receive, snapshot batching, holds, rollback, channel programs, pool wait)
 - **`truenas_pylibzfs.libzfs_types`** — all C extension types (`ZFSPool`, `ZFSDataset`, etc.) and enums (`ZFSType`, `ZPOOLProperty`, etc.); use for `isinstance` checks and enum access
+- **`truenas_pylibzfs.kstat`** — reads ZFS kernel statistics from `/proc/spl/kstat/zfs/` without linking to libzfs; currently provides `get_arcstats()`; ZIL statistics to follow
 
 This README covers a minimal set of usage examples. Where it conflicts with the inline docstrings or type stubs, treat those as authoritative. Docstrings are accessible at runtime via `help()`:
 
@@ -21,6 +22,8 @@ help(truenas_pylibzfs.libzfs_types.ZFSPool)   # pool methods
 help(truenas_pylibzfs.libzfs_types)          # all types and enums
 help(truenas_pylibzfs.lzc)          # lzc submodule
 help(truenas_pylibzfs.lzc.send)     # individual lzc method
+help(truenas_pylibzfs.kstat)        # kstat submodule overview
+help(truenas_pylibzfs.kstat.ArcStats)  # ArcStats field documentation
 ```
 
 ## Compatibility
@@ -51,7 +54,9 @@ Build in-place for development:
 python setup.py build_ext --inplace
 ```
 
-Type stubs (`stubs/__init__.pyi`, `stubs/lzc.pyi`) are installed as part of the `truenas_pylibzfs` package for IDE support.
+Type stubs are installed as part of the package for IDE support:
+
+- `stubs/__init__.pyi`, `stubs/lzc.pyi`, `stubs/libzfs_types.pyi`, `stubs/kstat.pyi` — for `truenas_pylibzfs` and its submodules
 
 ## Module Overview
 
@@ -596,6 +601,36 @@ except truenas_pylibzfs.ZFSException as e:
 
 ---
 
+## ZFS Kernel Statistics (`truenas_pylibzfs.kstat`)
+
+`truenas_pylibzfs.kstat` is a submodule that does not use libzfs and has no dependency on a `ZFS` handle. It reads files under `/proc/spl/kstat/zfs/` directly via stdio.
+
+```python
+from truenas_pylibzfs import kstat
+
+stats = kstat.get_arcstats()
+
+# Access fields by name
+print(stats.hits)
+print(stats.misses)
+print(stats.memory_available_bytes)  # signed; may be negative under memory pressure
+
+# Iterate all fields
+for name, value in zip(type(stats)._fields, stats):
+    print(f"{name}: {value}")
+
+# Successive calls return independent snapshots
+a = kstat.get_arcstats()
+b = kstat.get_arcstats()
+assert a is not b
+```
+
+`get_arcstats()` returns an `ArcStats` named-tuple-like object (`PyStructSequence`) with 147 integer fields. Field names and order match the kstat initializer in the ZFS source tree for the TrueNAS OpenZFS version; they are hard-coded at compile time. The CI test `tests/test_kstat_arcstats.py` verifies that the compiled field list stays in sync with `/proc/spl/kstat/zfs/arcstats` on the build host.
+
+`get_arcstats()` raises `OSError` if `/proc/spl/kstat/zfs/arcstats` cannot be opened (ZFS kernel module not loaded), and `ValueError` if the file format does not match expectations.
+
+---
+
 ## Source Layout
 
 ```
@@ -636,10 +671,15 @@ src/
   libzfs_core/
     py_zfs_core_module.c      # lzc submodule init, docstrings, method table
     libzfs_core_replication.c # send/receive/send_space/send_progress wrappers
+  pyzfs_kstat/
+    pyzfs_kstat.h             # state struct, path/field-count constants, extern declarations
+    pyzfs_kstat.c             # submodule init, PyDoc_STRVAR field docs, ArcStats type registration
+    arcstats.c                # get_arcstats() implementation
 stubs/
   __init__.pyi                # type stubs for truenas_pylibzfs
   lzc.pyi                     # type stubs for truenas_pylibzfs.lzc
   libzfs_types.pyi            # type stubs for truenas_pylibzfs.libzfs_types (types + enums)
+  kstat.pyi                   # type stubs for truenas_pylibzfs.kstat (ArcStats + get_arcstats)
   property_sets.pyi           # convenience frozensets of related properties
 tests/                        # pytest test suite
 examples/                     # runnable usage examples

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ truenas_pylibzfs = Extension(
         'src/libzfs/py_zfs_volume.c',
         'src/libzfs_core/py_zfs_core_module.c',
         'src/libzfs_core/libzfs_core_replication.c',
+        'src/pyzfs_kstat/pyzfs_kstat.c',
+        'src/pyzfs_kstat/arcstats.c',
     ],
     libraries = [
         'zfs',
@@ -52,5 +54,7 @@ setup(name='truenas_pylibzfs',
       ext_modules=[truenas_pylibzfs],
       packages=['truenas_pylibzfs'],
       package_dir={'truenas_pylibzfs': 'stubs'},
-      package_data={'truenas_pylibzfs': ['*.pyi', 'py.typed']})
+      package_data={
+          'truenas_pylibzfs': ['*.pyi', 'py.typed'],
+      })
 

--- a/src/README.md
+++ b/src/README.md
@@ -8,3 +8,5 @@ C source for the `truenas_pylibzfs` Python extension module.
   handle-based, requires a mutex for thread safety
 - [libzfs_core/README.md](libzfs_core/README.md) - bindings for the
   `libzfs_core` API; handle-free and thread-safe by design
+- [pyzfs_kstat/README.md](pyzfs_kstat/README.md) - ZFS kernel module
+  statistics reader; no libzfs dependency, reads directly from `/proc`

--- a/src/pyzfs_kstat/README.md
+++ b/src/pyzfs_kstat/README.md
@@ -1,0 +1,62 @@
+# src/pyzfs_kstat
+
+ZFS kernel module statistics reader, exposed as the `truenas_pylibzfs.kstat`
+submodule.
+
+## Overview
+
+Unlike the `libzfs` and `libzfs_core` bindings, this submodule has **no
+dependency on libzfs or any ZFS userland library**. It reads kstat files
+exposed by the ZFS kernel module under `/proc/spl/kstat/zfs/` via standard
+C stdio, making it lightweight and usable without opening a `ZFS` handle.
+
+Currently provides ARC (Adaptive Replacement Cache) statistics via
+`get_arcstats()`. ZIL statistics will follow.
+
+## Source files
+
+| File | Purpose |
+|---|---|
+| `pyzfs_kstat.h` | Module state struct, path/field-count constants, extern declarations |
+| `pyzfs_kstat.c` | Module init, `ArcStats` `PyStructSequence` type registration, `PyDoc_STRVAR` field docstrings, method table |
+| `arcstats.c` | `get_arcstats()` implementation -- reads and parses `/proc/spl/kstat/zfs/arcstats` |
+
+## Exposed methods
+
+| Python name | Source | Description |
+|---|---|---|
+| `get_arcstats()` | `arcstats.c` | Returns an `ArcStats` struct sequence with 147 integer fields |
+
+## Exposed types
+
+| Python name | Kind | Description |
+|---|---|---|
+| `ArcStats` | `PyStructSequence` | Named tuple-like object with one field per ARC kstat counter |
+
+## Developer notes
+
+### Adding a new kstat
+
+To add a new kstat (e.g. ZIL stats):
+
+1. Create a new `.c` file (e.g. `zilstats.c`) with the parsing function.
+2. Add `PyDoc_STRVAR` field docstrings and the `PyStructSequence_Desc` to
+   `pyzfs_kstat.c`.
+3. Extend `pyzfs_kstat_state_t` in `pyzfs_kstat.h` with the new type pointer
+   and update the field count constant.
+4. Register the new type in `py_setup_kstat_module()`.
+5. Add the new `.c` file to `setup.py`.
+6. Add a corresponding `.pyi` stub entry in `stubs/kstat.pyi`.
+
+### Field ordering
+
+Field names and order in the `PyStructSequence_Field` array must match the
+kstat initializer in the ZFS source tree (`module/zfs/arc.c` for ARC stats).
+The CI test `tests/test_kstat_arcstats.py` verifies this invariant against the
+live `/proc/spl/kstat/zfs/arcstats` file.
+
+### Docstrings
+
+All `PyDoc_STRVAR` definitions for field and method docstrings belong in
+`pyzfs_kstat.c`. Implementation files (e.g. `arcstats.c`) contain only
+parsing logic and no docstrings.

--- a/src/pyzfs_kstat/arcstats.c
+++ b/src/pyzfs_kstat/arcstats.c
@@ -1,0 +1,117 @@
+#include "pyzfs_kstat.h"
+
+#include <stdio.h>
+
+/*
+ * get_arcstats() implementation.
+ *
+ * Reads ARCSTATS_PATH and populates an ArcStats struct sequence whose type
+ * was created at module init by init_arcstats_type() in pyzfs_kstat.c.
+ *
+ * File format (from module/zfs/arc.c in the ZFS source tree):
+ *   Line 1: metadata header -- skip
+ *   Line 2: column names "name  type  data" -- skip
+ *   Line 3+: "<name>  <type>  <value>"
+ *     type 3 = KSTAT_DATA_INT64  (memory_available_bytes only, signed)
+ *     type 4 = KSTAT_DATA_UINT64 (all other fields, unsigned)
+ */
+PyObject *
+py_get_arcstats(PyObject *module, PyObject *args)
+{
+    pyzfs_kstat_state_t *state = NULL;
+    FILE *fp = NULL;
+    PyObject *result = NULL;
+    PyObject *val = NULL;
+    char line[256];
+    char name[64];
+    char valstr[24];
+    char *endptr = NULL;
+    int nscanned = 0;
+    int idx = 0;
+
+    PySys_Audit("truenas_pylibzfs.kstat.get_arcstats", NULL);
+
+    state = (pyzfs_kstat_state_t *)PyModule_GetState(module);
+
+    Py_BEGIN_ALLOW_THREADS
+    fp = fopen(ARCSTATS_PATH, "r");
+    Py_END_ALLOW_THREADS
+
+    if (fp == NULL) {
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, ARCSTATS_PATH);
+        return NULL;
+    }
+
+    /* Skip the two header lines. */
+    if (fgets(line, sizeof(line), fp) == NULL ||
+        fgets(line, sizeof(line), fp) == NULL) {
+        fclose(fp);
+        PyErr_SetString(PyExc_ValueError,
+            "Unexpected format in " ARCSTATS_PATH
+            ": missing header lines");
+        return NULL;
+    }
+
+    result = PyStructSequence_New(state->arcstats_type);
+    if (result == NULL) {
+        fclose(fp);
+        return NULL;
+    }
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        /*
+         * %*u discards the type column (KSTAT_DATA_INT64 = 3,
+         * KSTAT_DATA_UINT64 = 4). We do not need it: PyLong_FromString
+         * handles signed, unsigned, and arbitrary-precision values
+         * without requiring us to know the underlying C type.
+         */
+        nscanned = sscanf(line, "%63s %*u %23s", name, valstr);
+        if (nscanned != 2)
+            continue;
+
+        if (idx >= ARCSTATS_N_FIELDS) {
+            fclose(fp);
+            PyErr_Format(PyExc_ValueError,
+                ARCSTATS_PATH " has more than %d data fields. "
+                "Update arcstats.c and stubs to match the installed "
+                "ZFS version.",
+                ARCSTATS_N_FIELDS);
+            Py_DECREF(result);
+            return NULL;
+        }
+
+        val = PyLong_FromString(valstr, &endptr, 10);
+        if (val == NULL) {
+            fclose(fp);
+            Py_DECREF(result);
+            return NULL;
+        }
+        if (*endptr != '\0') {
+            fclose(fp);
+            Py_DECREF(val);
+            PyErr_Format(PyExc_ValueError,
+                ARCSTATS_PATH " field %d (%s): "
+                "trailing garbage in value \"%s\"",
+                idx, name, valstr);
+            Py_DECREF(result);
+            return NULL;
+        }
+
+        PyStructSequence_SetItem(result, idx, val); /* steals ref */
+        idx++;
+    }
+
+    fclose(fp);
+
+    if (idx != ARCSTATS_N_FIELDS) {
+        PyErr_Format(PyExc_ValueError,
+            ARCSTATS_PATH " has %d data fields; expected %d. "
+            "Update arcstats.c and stubs to match the installed "
+            "ZFS version.",
+            idx, ARCSTATS_N_FIELDS);
+        Py_DECREF(result);
+        return NULL;
+    }
+
+    return result;
+}

--- a/src/pyzfs_kstat/pyzfs_kstat.c
+++ b/src/pyzfs_kstat/pyzfs_kstat.c
@@ -1,0 +1,851 @@
+#include "pyzfs_kstat.h"
+
+/*
+ * truenas_pylibzfs.kstat -- ArcStats field docstrings and struct sequence
+ * definition.
+ *
+ * All PyDoc_STRVAR definitions for ArcStats fields live here, not in
+ * arcstats.c. arcstats.c contains only the file-parsing implementation.
+ *
+ * Field names and documentation are derived from:
+ *   module/zfs/arc.c       -- authoritative kstat name list
+ *   include/sys/arc_impl.h -- per-field comments
+ * in the ZFS source tree (github.com/truenas/zfs,
+ * branch truenas/zfs-2.4-release).
+ */
+
+/* -------------------------------------------------------------------------
+ * ArcStats field docstrings
+ * ------------------------------------------------------------------------- */
+
+/* Aggregate hit/miss counters */
+
+PyDoc_STRVAR(arcstat_hits__doc__,
+"ARC requests satisfied from cache without I/O "
+"(sum of all demand and prefetch, data and metadata hits).");
+
+PyDoc_STRVAR(arcstat_iohits__doc__,
+"ARC requests for which the required data was already being fetched "
+"by in-progress I/O at the time of the request.");
+
+PyDoc_STRVAR(arcstat_misses__doc__,
+"ARC requests that required issuing new I/O (cache miss).");
+
+/* Demand data */
+
+PyDoc_STRVAR(arcstat_demand_data_hits__doc__,
+"Demand data requests satisfied from the ARC without I/O.");
+
+PyDoc_STRVAR(arcstat_demand_data_iohits__doc__,
+"Demand data requests whose data was already being fetched by "
+"in-progress I/O.");
+
+PyDoc_STRVAR(arcstat_demand_data_misses__doc__,
+"Demand data requests that required new I/O (cache miss).");
+
+/* Demand metadata */
+
+PyDoc_STRVAR(arcstat_demand_metadata_hits__doc__,
+"Demand metadata requests satisfied from the ARC without I/O.");
+
+PyDoc_STRVAR(arcstat_demand_metadata_iohits__doc__,
+"Demand metadata requests whose data was already being fetched by "
+"in-progress I/O.");
+
+PyDoc_STRVAR(arcstat_demand_metadata_misses__doc__,
+"Demand metadata requests that required new I/O (cache miss).");
+
+/* Prefetch data */
+
+PyDoc_STRVAR(arcstat_prefetch_data_hits__doc__,
+"Prefetch data requests satisfied from the ARC without I/O.");
+
+PyDoc_STRVAR(arcstat_prefetch_data_iohits__doc__,
+"Prefetch data requests whose data was already being fetched by "
+"in-progress I/O.");
+
+PyDoc_STRVAR(arcstat_prefetch_data_misses__doc__,
+"Prefetch data requests that required new I/O (cache miss).");
+
+/* Prefetch metadata */
+
+PyDoc_STRVAR(arcstat_prefetch_metadata_hits__doc__,
+"Prefetch metadata requests satisfied from the ARC without I/O.");
+
+PyDoc_STRVAR(arcstat_prefetch_metadata_iohits__doc__,
+"Prefetch metadata requests whose data was already being fetched by "
+"in-progress I/O.");
+
+PyDoc_STRVAR(arcstat_prefetch_metadata_misses__doc__,
+"Prefetch metadata requests that required new I/O (cache miss).");
+
+/* ARC state hits */
+
+PyDoc_STRVAR(arcstat_mru_hits__doc__,
+"ARC hits on buffers in the MRU (Most Recently Used) state.");
+
+PyDoc_STRVAR(arcstat_mru_ghost_hits__doc__,
+"ARC hits on the MRU ghost list. Ghost entries track recently evicted "
+"MRU buffers to bias re-admission toward MRU on the next access.");
+
+PyDoc_STRVAR(arcstat_mfu_hits__doc__,
+"ARC hits on buffers in the MFU (Most Frequently Used) state.");
+
+PyDoc_STRVAR(arcstat_mfu_ghost_hits__doc__,
+"ARC hits on the MFU ghost list. Ghost entries track recently evicted "
+"MFU buffers to bias re-admission toward MFU on the next access.");
+
+PyDoc_STRVAR(arcstat_uncached_hits__doc__,
+"ARC hits on buffers marked ARC_FLAG_UNCACHED (scheduled for eviction "
+"on the next opportunity).");
+
+PyDoc_STRVAR(arcstat_deleted__doc__,
+"ARC buffers deleted (freed) from the cache.");
+
+/* Eviction */
+
+PyDoc_STRVAR(arcstat_mutex_miss__doc__,
+"Evictions skipped because the buffer's hash lock was held by another "
+"thread. Hash locks are shared across multiple buffers so contention "
+"may not involve the target buffer.");
+
+PyDoc_STRVAR(arcstat_access_skip__doc__,
+"Buffers skipped during access state update because the header was "
+"released after the hash lock was acquired.");
+
+PyDoc_STRVAR(arcstat_evict_skip__doc__,
+"Buffers skipped during eviction because they had I/O in progress, "
+"were indirect prefetch buffers that had not lived long enough, or "
+"belonged to a different pool.");
+
+PyDoc_STRVAR(arcstat_evict_not_enough__doc__,
+"Times arc_evict_state() could not evict enough buffers to reach its "
+"target amount.");
+
+PyDoc_STRVAR(arcstat_evict_l2_cached__doc__,
+"Bytes evicted from ARC that were already cached on an L2ARC device.");
+
+PyDoc_STRVAR(arcstat_evict_l2_eligible__doc__,
+"Bytes evicted from ARC that were eligible for caching on L2ARC.");
+
+PyDoc_STRVAR(arcstat_evict_l2_eligible_mfu__doc__,
+"MFU bytes evicted from ARC that were eligible for L2ARC caching.");
+
+PyDoc_STRVAR(arcstat_evict_l2_eligible_mru__doc__,
+"MRU bytes evicted from ARC that were eligible for L2ARC caching.");
+
+PyDoc_STRVAR(arcstat_evict_l2_ineligible__doc__,
+"Bytes evicted from ARC that were ineligible for L2ARC caching "
+"(e.g. encrypted data or data that is already on L2ARC).");
+
+PyDoc_STRVAR(arcstat_evict_l2_skip__doc__,
+"ARC evictions for which the L2ARC write was skipped.");
+
+/* Hash table */
+
+PyDoc_STRVAR(arcstat_hash_elements__doc__,
+"Current number of elements in the ARC hash table.");
+
+PyDoc_STRVAR(arcstat_hash_elements_max__doc__,
+"Peak number of elements ever resident in the ARC hash table.");
+
+PyDoc_STRVAR(arcstat_hash_collisions__doc__,
+"Total number of hash collisions recorded in the ARC hash table.");
+
+PyDoc_STRVAR(arcstat_hash_chains__doc__,
+"Number of hash chains (buckets with more than one element) in the "
+"ARC hash table.");
+
+PyDoc_STRVAR(arcstat_hash_chain_max__doc__,
+"Length of the longest hash chain ever observed in the ARC hash table.");
+
+/* Cache size targets (bytes) */
+
+PyDoc_STRVAR(arcstat_meta__doc__,
+"ARC metadata limit in bytes (arc_meta_limit). Metadata consumption "
+"above this target triggers eviction of metadata buffers.");
+
+PyDoc_STRVAR(arcstat_pd__doc__,
+"ARC prefetch data target size in bytes.");
+
+PyDoc_STRVAR(arcstat_pm__doc__,
+"ARC prefetch metadata target size in bytes.");
+
+PyDoc_STRVAR(arcstat_c__doc__,
+"Current ARC target size in bytes. The ARC grows toward arc_c_max and "
+"shrinks toward arc_c_min in response to memory pressure.");
+
+PyDoc_STRVAR(arcstat_c_min__doc__,
+"Minimum ARC target size in bytes (arc_c_min). The ARC will not shrink "
+"below this value.");
+
+PyDoc_STRVAR(arcstat_c_max__doc__,
+"Maximum ARC target size in bytes (arc_c_max). The ARC will not grow "
+"beyond this value.");
+
+/* Overall size (bytes) */
+
+PyDoc_STRVAR(arcstat_size__doc__,
+"Total size of all ARC-cached buffers in bytes.");
+
+PyDoc_STRVAR(arcstat_compressed_size__doc__,
+"Compressed size in bytes of data stored in arc_buf_hdr_t b_pabd "
+"fields. Equals uncompressed_size when compressed ARC is disabled.");
+
+PyDoc_STRVAR(arcstat_uncompressed_size__doc__,
+"Uncompressed size in bytes of data stored in arc_buf_hdr_t b_pabd "
+"fields. Equals compressed_size when compressed ARC is disabled.");
+
+PyDoc_STRVAR(arcstat_overhead_size__doc__,
+"Bytes held in short-lived uncompressed arc_buf_t copies attached to "
+"headers. These copies are evicted when unreferenced unless "
+"zfs_keep_uncompressed_metadata or zfs_keep_uncompressed_level is set.");
+
+PyDoc_STRVAR(arcstat_hdr_size__doc__,
+"Bytes consumed by internal ARC tracking structures (arc_buf_hdr_t and "
+"arc_buf_t objects). These structures are not backed by ARC data "
+"buffers.");
+
+PyDoc_STRVAR(arcstat_data_size__doc__,
+"Bytes consumed by ARC_BUFC_DATA buffers, which back on-disk user "
+"data such as plain file contents.");
+
+PyDoc_STRVAR(arcstat_metadata_size__doc__,
+"Bytes consumed by ARC_BUFC_METADATA buffers, which back internal ZFS "
+"structures such as ZAP objects, dnodes, and indirect blocks.");
+
+PyDoc_STRVAR(arcstat_dbuf_size__doc__,
+"Bytes consumed by dmu_buf_impl_t (dbuf) objects.");
+
+PyDoc_STRVAR(arcstat_dnode_size__doc__,
+"Bytes consumed by dnode_t objects.");
+
+PyDoc_STRVAR(arcstat_bonus_size__doc__,
+"Bytes consumed by dnode bonus buffers.");
+
+/* Anon state (bytes) */
+
+PyDoc_STRVAR(arcstat_anon_size__doc__,
+"Total bytes in the arc_anon state. Anon buffers are newly allocated "
+"and have not yet been promoted to MRU or MFU.");
+
+PyDoc_STRVAR(arcstat_anon_data__doc__,
+"ARC_BUFC_DATA bytes in the arc_anon state.");
+
+PyDoc_STRVAR(arcstat_anon_metadata__doc__,
+"ARC_BUFC_METADATA bytes in the arc_anon state.");
+
+PyDoc_STRVAR(arcstat_anon_evictable_data__doc__,
+"Evictable ARC_BUFC_DATA bytes in the arc_anon state "
+"(no outstanding holds on the buffer).");
+
+PyDoc_STRVAR(arcstat_anon_evictable_metadata__doc__,
+"Evictable ARC_BUFC_METADATA bytes in the arc_anon state "
+"(no outstanding holds on the buffer).");
+
+/* MRU state (bytes) */
+
+PyDoc_STRVAR(arcstat_mru_size__doc__,
+"Total bytes in the MRU (Most Recently Used) state, including data, "
+"metadata, evictable, and pinned buffers.");
+
+PyDoc_STRVAR(arcstat_mru_data__doc__,
+"ARC_BUFC_DATA bytes in the MRU state.");
+
+PyDoc_STRVAR(arcstat_mru_metadata__doc__,
+"ARC_BUFC_METADATA bytes in the MRU state.");
+
+PyDoc_STRVAR(arcstat_mru_evictable_data__doc__,
+"Evictable ARC_BUFC_DATA bytes in the MRU state "
+"(no outstanding holds on the buffer).");
+
+PyDoc_STRVAR(arcstat_mru_evictable_metadata__doc__,
+"Evictable ARC_BUFC_METADATA bytes in the MRU state "
+"(no outstanding holds on the buffer).");
+
+/* MRU ghost state (bytes) */
+
+PyDoc_STRVAR(arcstat_mru_ghost_size__doc__,
+"Notional bytes tracked by MRU ghost headers. Ghost lists hold only "
+"headers with no associated data buffers; this value represents what "
+"those buffers would have consumed had they remained cached.");
+
+PyDoc_STRVAR(arcstat_mru_ghost_data__doc__,
+"Notional ARC_BUFC_DATA bytes tracked by MRU ghost headers.");
+
+PyDoc_STRVAR(arcstat_mru_ghost_metadata__doc__,
+"Notional ARC_BUFC_METADATA bytes tracked by MRU ghost headers.");
+
+PyDoc_STRVAR(arcstat_mru_ghost_evictable_data__doc__,
+"Notional evictable ARC_BUFC_DATA bytes on the MRU ghost list.");
+
+PyDoc_STRVAR(arcstat_mru_ghost_evictable_metadata__doc__,
+"Notional evictable ARC_BUFC_METADATA bytes on the MRU ghost list.");
+
+/* MFU state (bytes) */
+
+PyDoc_STRVAR(arcstat_mfu_size__doc__,
+"Total bytes in the MFU (Most Frequently Used) state, including data, "
+"metadata, evictable, and pinned buffers.");
+
+PyDoc_STRVAR(arcstat_mfu_data__doc__,
+"ARC_BUFC_DATA bytes in the MFU state.");
+
+PyDoc_STRVAR(arcstat_mfu_metadata__doc__,
+"ARC_BUFC_METADATA bytes in the MFU state.");
+
+PyDoc_STRVAR(arcstat_mfu_evictable_data__doc__,
+"Evictable ARC_BUFC_DATA bytes in the MFU state "
+"(no outstanding holds on the buffer).");
+
+PyDoc_STRVAR(arcstat_mfu_evictable_metadata__doc__,
+"Evictable ARC_BUFC_METADATA bytes in the MFU state "
+"(no outstanding holds on the buffer).");
+
+/* MFU ghost state (bytes) */
+
+PyDoc_STRVAR(arcstat_mfu_ghost_size__doc__,
+"Notional bytes tracked by MFU ghost headers. "
+"See mru_ghost_size for a full description of ghost lists.");
+
+PyDoc_STRVAR(arcstat_mfu_ghost_data__doc__,
+"Notional ARC_BUFC_DATA bytes tracked by MFU ghost headers.");
+
+PyDoc_STRVAR(arcstat_mfu_ghost_metadata__doc__,
+"Notional ARC_BUFC_METADATA bytes tracked by MFU ghost headers.");
+
+PyDoc_STRVAR(arcstat_mfu_ghost_evictable_data__doc__,
+"Notional evictable ARC_BUFC_DATA bytes on the MFU ghost list.");
+
+PyDoc_STRVAR(arcstat_mfu_ghost_evictable_metadata__doc__,
+"Notional evictable ARC_BUFC_METADATA bytes on the MFU ghost list.");
+
+/* Uncached state (bytes) */
+
+PyDoc_STRVAR(arcstat_uncached_size__doc__,
+"Total bytes pending eviction from ARC because ARC_FLAG_UNCACHED is "
+"set. These buffers will be freed on the next eviction pass.");
+
+PyDoc_STRVAR(arcstat_uncached_data__doc__,
+"ARC_BUFC_DATA bytes pending eviction due to ARC_FLAG_UNCACHED.");
+
+PyDoc_STRVAR(arcstat_uncached_metadata__doc__,
+"ARC_BUFC_METADATA bytes pending eviction due to ARC_FLAG_UNCACHED.");
+
+PyDoc_STRVAR(arcstat_uncached_evictable_data__doc__,
+"Evictable ARC_BUFC_DATA bytes pending eviction due to ARC_FLAG_UNCACHED "
+"(no outstanding holds on the buffer).");
+
+PyDoc_STRVAR(arcstat_uncached_evictable_metadata__doc__,
+"Evictable ARC_BUFC_METADATA bytes pending eviction due to "
+"ARC_FLAG_UNCACHED (no outstanding holds on the buffer).");
+
+/* L2ARC (Level 2 ARC cache device) */
+
+PyDoc_STRVAR(arcstat_l2_hits__doc__,
+"L2ARC (Level 2 ARC cache device) read hits.");
+
+PyDoc_STRVAR(arcstat_l2_misses__doc__,
+"L2ARC read misses (data not found in L2ARC; fell through to disk).");
+
+PyDoc_STRVAR(arcstat_l2_prefetch_asize__doc__,
+"Allocated bytes of L2ARC-cached buffers originating from the prefetch "
+"ARC state.");
+
+PyDoc_STRVAR(arcstat_l2_mru_asize__doc__,
+"Allocated bytes of L2ARC-cached buffers originating from the MRU state.");
+
+PyDoc_STRVAR(arcstat_l2_mfu_asize__doc__,
+"Allocated bytes of L2ARC-cached buffers originating from the MFU state.");
+
+PyDoc_STRVAR(arcstat_l2_bufc_data_asize__doc__,
+"Allocated bytes of L2ARC-cached ARC_BUFC_DATA buffers.");
+
+PyDoc_STRVAR(arcstat_l2_bufc_metadata_asize__doc__,
+"Allocated bytes of L2ARC-cached ARC_BUFC_METADATA buffers.");
+
+PyDoc_STRVAR(arcstat_l2_feeds__doc__,
+"Number of ARC header batches (feeds) sent to L2ARC for writing.");
+
+PyDoc_STRVAR(arcstat_l2_rw_clash__doc__,
+"ARC evictions skipped because an L2ARC write was in progress on the "
+"buffer at the time of eviction.");
+
+PyDoc_STRVAR(arcstat_l2_read_bytes__doc__,
+"Total bytes read from L2ARC devices.");
+
+PyDoc_STRVAR(arcstat_l2_write_bytes__doc__,
+"Total bytes written to L2ARC devices.");
+
+PyDoc_STRVAR(arcstat_l2_writes_sent__doc__,
+"L2ARC write I/Os issued.");
+
+PyDoc_STRVAR(arcstat_l2_writes_done__doc__,
+"L2ARC write I/Os completed successfully.");
+
+PyDoc_STRVAR(arcstat_l2_writes_error__doc__,
+"L2ARC write I/Os that completed with errors.");
+
+PyDoc_STRVAR(arcstat_l2_writes_lock_retry__doc__,
+"L2ARC write attempts that had to retry due to lock contention.");
+
+PyDoc_STRVAR(arcstat_l2_evict_lock_retry__doc__,
+"L2ARC eviction attempts that had to retry due to lock contention.");
+
+PyDoc_STRVAR(arcstat_l2_evict_reading__doc__,
+"L2ARC buffers skipped for eviction because a read was in progress on "
+"the buffer.");
+
+PyDoc_STRVAR(arcstat_l2_evict_l1cached__doc__,
+"L2ARC buffers evicted from L2ARC that were still present in L1 ARC.");
+
+PyDoc_STRVAR(arcstat_l2_free_on_write__doc__,
+"L2ARC buffers queued to be freed on the next L2ARC write.");
+
+PyDoc_STRVAR(arcstat_l2_abort_lowmem__doc__,
+"L2ARC write passes aborted because system memory was too low to "
+"proceed safely.");
+
+PyDoc_STRVAR(arcstat_l2_cksum_bad__doc__,
+"L2ARC reads that failed due to a checksum mismatch.");
+
+PyDoc_STRVAR(arcstat_l2_io_error__doc__,
+"L2ARC reads that failed due to an I/O error.");
+
+PyDoc_STRVAR(arcstat_l2_size__doc__,
+"Logical (uncompressed) size in bytes of all data currently cached on "
+"L2ARC devices.");
+
+PyDoc_STRVAR(arcstat_l2_asize__doc__,
+"Actual (compressed, device-aligned) size in bytes of all data currently "
+"stored on L2ARC devices.");
+
+PyDoc_STRVAR(arcstat_l2_hdr_size__doc__,
+"Bytes consumed by L2ARC buffer header structures resident in L1 ARC "
+"memory.");
+
+/* L2ARC log blocks (persistent L2ARC rebuild) */
+
+PyDoc_STRVAR(arcstat_l2_log_blk_writes__doc__,
+"Number of L2ARC log blocks written. Log blocks record which ARC buffers "
+"are stored on L2ARC and enable the cache to be rebuilt after a pool "
+"import without re-reading all data from disk.");
+
+PyDoc_STRVAR(arcstat_l2_log_blk_avg_asize__doc__,
+"Moving average of the aligned size in bytes of L2ARC log blocks. "
+"Updated during L2ARC rebuild and during log block writes.");
+
+PyDoc_STRVAR(arcstat_l2_log_blk_asize__doc__,
+"Total aligned size in bytes of all L2ARC log blocks currently on "
+"L2ARC devices.");
+
+PyDoc_STRVAR(arcstat_l2_log_blk_count__doc__,
+"Number of L2ARC log blocks currently present on L2ARC devices.");
+
+PyDoc_STRVAR(arcstat_l2_data_to_meta_ratio__doc__,
+"Moving average ratio of restored L2ARC data size to the aligned size "
+"of its log metadata. Updated during L2ARC rebuild and log block writes.");
+
+/* L2ARC rebuild */
+
+PyDoc_STRVAR(arcstat_l2_rebuild_success__doc__,
+"Number of L2ARC devices for which log-based rebuild completed "
+"successfully on pool import.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_unsupported__doc__,
+"L2ARC rebuild attempts aborted because the device header was in an "
+"unsupported format or was corrupted.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_io_errors__doc__,
+"L2ARC rebuild attempts aborted due to I/O errors while reading a log "
+"block.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_dh_errors__doc__,
+"L2ARC rebuild attempts aborted due to I/O errors while reading the "
+"device header.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_cksum_lb_errors__doc__,
+"L2ARC log blocks skipped during rebuild due to checksum errors.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_lowmem__doc__,
+"L2ARC rebuild attempts aborted because system memory was too low.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_size__doc__,
+"Logical size in bytes of L2ARC data restored during the last rebuild.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_asize__doc__,
+"Aligned (on-device) size in bytes of L2ARC data restored during the "
+"last rebuild.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_bufs__doc__,
+"Number of L2ARC log entries (buffers) successfully restored to ARC "
+"during rebuild.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_bufs_precached__doc__,
+"Number of L2ARC log entries skipped during rebuild because those "
+"buffers were already cached in L1 ARC.");
+
+PyDoc_STRVAR(arcstat_l2_rebuild_log_blks__doc__,
+"Number of L2ARC log blocks successfully read during rebuild. Each log "
+"block may describe up to L2ARC_LOG_BLK_MAX_ENTRIES buffers.");
+
+/* Memory */
+
+PyDoc_STRVAR(arcstat_memory_throttle_count__doc__,
+"Number of times ARC was asked to shrink in response to memory pressure "
+"(throttle events triggered by the kernel reclaim path).");
+
+PyDoc_STRVAR(arcstat_memory_direct_count__doc__,
+"Number of direct memory reclaim events where the ARC shrank "
+"synchronously to satisfy memory pressure.");
+
+PyDoc_STRVAR(arcstat_memory_indirect_count__doc__,
+"Number of indirect memory reclaim events where the ARC shrank "
+"asynchronously in response to memory pressure.");
+
+PyDoc_STRVAR(arcstat_memory_all_bytes__doc__,
+"Total system memory in bytes as reported to the ARC.");
+
+PyDoc_STRVAR(arcstat_memory_free_bytes__doc__,
+"Free system memory in bytes as reported to the ARC.");
+
+PyDoc_STRVAR(arcstat_memory_available_bytes__doc__,
+"Estimated memory in bytes currently available for ARC growth. "
+"Signed value (KSTAT_DATA_INT64); may be negative under sustained "
+"memory pressure when the ARC owes memory back to the system.");
+
+/* ARC control and state */
+
+PyDoc_STRVAR(arcstat_no_grow__doc__,
+"Non-zero when the ARC is suppressing growth due to memory pressure.");
+
+PyDoc_STRVAR(arcstat_tempreserve__doc__,
+"Bytes temporarily reserved in the ARC for in-progress dirty data "
+"writes. Released when the write completes.");
+
+PyDoc_STRVAR(arcstat_loaned_bytes__doc__,
+"Bytes loaned from the ARC to other kernel subsystems (e.g. for "
+"zero-copy I/O staging). Counted against the ARC size target.");
+
+PyDoc_STRVAR(arcstat_prune__doc__,
+"Number of times the ARC requested that registered subsystems release "
+"memory via prune callbacks.");
+
+PyDoc_STRVAR(arcstat_meta_used__doc__,
+"Total ARC bytes consumed by metadata: sum of hdr_size, metadata_size, "
+"dbuf_size, dnode_size, and bonus_size.");
+
+PyDoc_STRVAR(arcstat_dnode_limit__doc__,
+"Target upper bound in bytes for dnode_size within the ARC. Dnode "
+"eviction is triggered when dnode_size approaches this limit.");
+
+/* Prefetch */
+
+PyDoc_STRVAR(arcstat_async_upgrade_sync__doc__,
+"Async prefetch requests that were upgraded to synchronous because a "
+"demand read arrived before the prefetch completed.");
+
+PyDoc_STRVAR(arcstat_predictive_prefetch__doc__,
+"Predictive prefetch requests issued. Predictive prefetch detects "
+"sequential access patterns and fetches data ahead of demand.");
+
+PyDoc_STRVAR(arcstat_demand_hit_predictive_prefetch__doc__,
+"Demand reads satisfied by a predictive prefetch that had already "
+"completed (prefetch was useful).");
+
+PyDoc_STRVAR(arcstat_demand_iohit_predictive_prefetch__doc__,
+"Demand reads that found a predictive prefetch already in progress "
+"(overlapping prefetch and demand I/O).");
+
+PyDoc_STRVAR(arcstat_prescient_prefetch__doc__,
+"Prescient prefetch requests issued. Prescient prefetch uses explicit "
+"read-ahead hints from upper layers such as dmu_prefetch.");
+
+PyDoc_STRVAR(arcstat_demand_hit_prescient_prefetch__doc__,
+"Demand reads satisfied by a prescient prefetch that had already "
+"completed (prefetch was useful).");
+
+PyDoc_STRVAR(arcstat_demand_iohit_prescient_prefetch__doc__,
+"Demand reads that found a prescient prefetch already in progress "
+"(overlapping prefetch and demand I/O).");
+
+/* Miscellaneous */
+
+PyDoc_STRVAR(arcstat_need_free__doc__,
+"Bytes the ARC is currently working to free in order to satisfy "
+"outstanding memory pressure requests.");
+
+PyDoc_STRVAR(arcstat_sys_free__doc__,
+"Free memory target in bytes that the ARC aims to maintain for the "
+"rest of the system.");
+
+PyDoc_STRVAR(arcstat_raw_size__doc__,
+"Bytes of encrypted (raw/ciphertext) data currently cached in the ARC.");
+
+PyDoc_STRVAR(arcstat_cached_only_in_progress__doc__,
+"Non-zero while a cache-only (dry-run) traversal of the pool is active.");
+
+PyDoc_STRVAR(arcstat_abd_chunk_waste_size__doc__,
+"Bytes wasted due to ABD (Aggregation Buffer Descriptor) chunk alignment "
+"padding. ABDs allocate memory in fixed-size chunks; unused space at the "
+"end of the last chunk of each allocation contributes to this counter.");
+
+/* -------------------------------------------------------------------------
+ * ArcStats struct sequence definition
+ *
+ * Field order must match the arc_stats initializer in module/zfs/arc.c
+ * (lines 503-654, excluding the COMPAT_FREEBSD11-only "other_size" entry).
+ *
+ * The test tests/test_kstat_arcstats.py verifies this order against the
+ * live " ARCSTATS_PATH " file in CI.
+ * ------------------------------------------------------------------------- */
+
+static PyStructSequence_Field arcstats_fields[] = {
+    {"hits", arcstat_hits__doc__},
+    {"iohits", arcstat_iohits__doc__},
+    {"misses", arcstat_misses__doc__},
+    {"demand_data_hits", arcstat_demand_data_hits__doc__},
+    {"demand_data_iohits", arcstat_demand_data_iohits__doc__},
+    {"demand_data_misses", arcstat_demand_data_misses__doc__},
+    {"demand_metadata_hits", arcstat_demand_metadata_hits__doc__},
+    {"demand_metadata_iohits", arcstat_demand_metadata_iohits__doc__},
+    {"demand_metadata_misses", arcstat_demand_metadata_misses__doc__},
+    {"prefetch_data_hits", arcstat_prefetch_data_hits__doc__},
+    {"prefetch_data_iohits", arcstat_prefetch_data_iohits__doc__},
+    {"prefetch_data_misses", arcstat_prefetch_data_misses__doc__},
+    {"prefetch_metadata_hits", arcstat_prefetch_metadata_hits__doc__},
+    {"prefetch_metadata_iohits", arcstat_prefetch_metadata_iohits__doc__},
+    {"prefetch_metadata_misses", arcstat_prefetch_metadata_misses__doc__},
+    {"mru_hits", arcstat_mru_hits__doc__},
+    {"mru_ghost_hits", arcstat_mru_ghost_hits__doc__},
+    {"mfu_hits", arcstat_mfu_hits__doc__},
+    {"mfu_ghost_hits", arcstat_mfu_ghost_hits__doc__},
+    {"uncached_hits", arcstat_uncached_hits__doc__},
+    {"deleted", arcstat_deleted__doc__},
+    {"mutex_miss", arcstat_mutex_miss__doc__},
+    {"access_skip", arcstat_access_skip__doc__},
+    {"evict_skip", arcstat_evict_skip__doc__},
+    {"evict_not_enough", arcstat_evict_not_enough__doc__},
+    {"evict_l2_cached", arcstat_evict_l2_cached__doc__},
+    {"evict_l2_eligible", arcstat_evict_l2_eligible__doc__},
+    {"evict_l2_eligible_mfu", arcstat_evict_l2_eligible_mfu__doc__},
+    {"evict_l2_eligible_mru", arcstat_evict_l2_eligible_mru__doc__},
+    {"evict_l2_ineligible", arcstat_evict_l2_ineligible__doc__},
+    {"evict_l2_skip", arcstat_evict_l2_skip__doc__},
+    {"hash_elements", arcstat_hash_elements__doc__},
+    {"hash_elements_max", arcstat_hash_elements_max__doc__},
+    {"hash_collisions", arcstat_hash_collisions__doc__},
+    {"hash_chains", arcstat_hash_chains__doc__},
+    {"hash_chain_max", arcstat_hash_chain_max__doc__},
+    {"meta", arcstat_meta__doc__},
+    {"pd", arcstat_pd__doc__},
+    {"pm", arcstat_pm__doc__},
+    {"c", arcstat_c__doc__},
+    {"c_min", arcstat_c_min__doc__},
+    {"c_max", arcstat_c_max__doc__},
+    {"size", arcstat_size__doc__},
+    {"compressed_size", arcstat_compressed_size__doc__},
+    {"uncompressed_size", arcstat_uncompressed_size__doc__},
+    {"overhead_size", arcstat_overhead_size__doc__},
+    {"hdr_size", arcstat_hdr_size__doc__},
+    {"data_size", arcstat_data_size__doc__},
+    {"metadata_size", arcstat_metadata_size__doc__},
+    {"dbuf_size", arcstat_dbuf_size__doc__},
+    {"dnode_size", arcstat_dnode_size__doc__},
+    {"bonus_size", arcstat_bonus_size__doc__},
+    {"anon_size", arcstat_anon_size__doc__},
+    {"anon_data", arcstat_anon_data__doc__},
+    {"anon_metadata", arcstat_anon_metadata__doc__},
+    {"anon_evictable_data", arcstat_anon_evictable_data__doc__},
+    {"anon_evictable_metadata", arcstat_anon_evictable_metadata__doc__},
+    {"mru_size", arcstat_mru_size__doc__},
+    {"mru_data", arcstat_mru_data__doc__},
+    {"mru_metadata", arcstat_mru_metadata__doc__},
+    {"mru_evictable_data", arcstat_mru_evictable_data__doc__},
+    {"mru_evictable_metadata", arcstat_mru_evictable_metadata__doc__},
+    {"mru_ghost_size", arcstat_mru_ghost_size__doc__},
+    {"mru_ghost_data", arcstat_mru_ghost_data__doc__},
+    {"mru_ghost_metadata", arcstat_mru_ghost_metadata__doc__},
+    {"mru_ghost_evictable_data", arcstat_mru_ghost_evictable_data__doc__},
+    {"mru_ghost_evictable_metadata", arcstat_mru_ghost_evictable_metadata__doc__},
+    {"mfu_size", arcstat_mfu_size__doc__},
+    {"mfu_data", arcstat_mfu_data__doc__},
+    {"mfu_metadata", arcstat_mfu_metadata__doc__},
+    {"mfu_evictable_data", arcstat_mfu_evictable_data__doc__},
+    {"mfu_evictable_metadata", arcstat_mfu_evictable_metadata__doc__},
+    {"mfu_ghost_size", arcstat_mfu_ghost_size__doc__},
+    {"mfu_ghost_data", arcstat_mfu_ghost_data__doc__},
+    {"mfu_ghost_metadata", arcstat_mfu_ghost_metadata__doc__},
+    {"mfu_ghost_evictable_data", arcstat_mfu_ghost_evictable_data__doc__},
+    {"mfu_ghost_evictable_metadata", arcstat_mfu_ghost_evictable_metadata__doc__},
+    {"uncached_size", arcstat_uncached_size__doc__},
+    {"uncached_data", arcstat_uncached_data__doc__},
+    {"uncached_metadata", arcstat_uncached_metadata__doc__},
+    {"uncached_evictable_data", arcstat_uncached_evictable_data__doc__},
+    {"uncached_evictable_metadata", arcstat_uncached_evictable_metadata__doc__},
+    {"l2_hits", arcstat_l2_hits__doc__},
+    {"l2_misses", arcstat_l2_misses__doc__},
+    {"l2_prefetch_asize", arcstat_l2_prefetch_asize__doc__},
+    {"l2_mru_asize", arcstat_l2_mru_asize__doc__},
+    {"l2_mfu_asize", arcstat_l2_mfu_asize__doc__},
+    {"l2_bufc_data_asize", arcstat_l2_bufc_data_asize__doc__},
+    {"l2_bufc_metadata_asize", arcstat_l2_bufc_metadata_asize__doc__},
+    {"l2_feeds", arcstat_l2_feeds__doc__},
+    {"l2_rw_clash", arcstat_l2_rw_clash__doc__},
+    {"l2_read_bytes", arcstat_l2_read_bytes__doc__},
+    {"l2_write_bytes", arcstat_l2_write_bytes__doc__},
+    {"l2_writes_sent", arcstat_l2_writes_sent__doc__},
+    {"l2_writes_done", arcstat_l2_writes_done__doc__},
+    {"l2_writes_error", arcstat_l2_writes_error__doc__},
+    {"l2_writes_lock_retry", arcstat_l2_writes_lock_retry__doc__},
+    {"l2_evict_lock_retry", arcstat_l2_evict_lock_retry__doc__},
+    {"l2_evict_reading", arcstat_l2_evict_reading__doc__},
+    {"l2_evict_l1cached", arcstat_l2_evict_l1cached__doc__},
+    {"l2_free_on_write", arcstat_l2_free_on_write__doc__},
+    {"l2_abort_lowmem", arcstat_l2_abort_lowmem__doc__},
+    {"l2_cksum_bad", arcstat_l2_cksum_bad__doc__},
+    {"l2_io_error", arcstat_l2_io_error__doc__},
+    {"l2_size", arcstat_l2_size__doc__},
+    {"l2_asize", arcstat_l2_asize__doc__},
+    {"l2_hdr_size", arcstat_l2_hdr_size__doc__},
+    {"l2_log_blk_writes", arcstat_l2_log_blk_writes__doc__},
+    {"l2_log_blk_avg_asize", arcstat_l2_log_blk_avg_asize__doc__},
+    {"l2_log_blk_asize", arcstat_l2_log_blk_asize__doc__},
+    {"l2_log_blk_count", arcstat_l2_log_blk_count__doc__},
+    {"l2_data_to_meta_ratio", arcstat_l2_data_to_meta_ratio__doc__},
+    {"l2_rebuild_success", arcstat_l2_rebuild_success__doc__},
+    {"l2_rebuild_unsupported", arcstat_l2_rebuild_unsupported__doc__},
+    {"l2_rebuild_io_errors", arcstat_l2_rebuild_io_errors__doc__},
+    {"l2_rebuild_dh_errors", arcstat_l2_rebuild_dh_errors__doc__},
+    {"l2_rebuild_cksum_lb_errors", arcstat_l2_rebuild_cksum_lb_errors__doc__},
+    {"l2_rebuild_lowmem", arcstat_l2_rebuild_lowmem__doc__},
+    {"l2_rebuild_size", arcstat_l2_rebuild_size__doc__},
+    {"l2_rebuild_asize", arcstat_l2_rebuild_asize__doc__},
+    {"l2_rebuild_bufs", arcstat_l2_rebuild_bufs__doc__},
+    {"l2_rebuild_bufs_precached", arcstat_l2_rebuild_bufs_precached__doc__},
+    {"l2_rebuild_log_blks", arcstat_l2_rebuild_log_blks__doc__},
+    {"memory_throttle_count", arcstat_memory_throttle_count__doc__},
+    {"memory_direct_count", arcstat_memory_direct_count__doc__},
+    {"memory_indirect_count", arcstat_memory_indirect_count__doc__},
+    {"memory_all_bytes", arcstat_memory_all_bytes__doc__},
+    {"memory_free_bytes", arcstat_memory_free_bytes__doc__},
+    {"memory_available_bytes", arcstat_memory_available_bytes__doc__},
+    {"arc_no_grow", arcstat_no_grow__doc__},
+    {"arc_tempreserve", arcstat_tempreserve__doc__},
+    {"arc_loaned_bytes", arcstat_loaned_bytes__doc__},
+    {"arc_prune", arcstat_prune__doc__},
+    {"arc_meta_used", arcstat_meta_used__doc__},
+    {"arc_dnode_limit", arcstat_dnode_limit__doc__},
+    {"async_upgrade_sync", arcstat_async_upgrade_sync__doc__},
+    {"predictive_prefetch", arcstat_predictive_prefetch__doc__},
+    {"demand_hit_predictive_prefetch", arcstat_demand_hit_predictive_prefetch__doc__},
+    {"demand_iohit_predictive_prefetch", arcstat_demand_iohit_predictive_prefetch__doc__},
+    {"prescient_prefetch", arcstat_prescient_prefetch__doc__},
+    {"demand_hit_prescient_prefetch", arcstat_demand_hit_prescient_prefetch__doc__},
+    {"demand_iohit_prescient_prefetch", arcstat_demand_iohit_prescient_prefetch__doc__},
+    {"arc_need_free", arcstat_need_free__doc__},
+    {"arc_sys_free", arcstat_sys_free__doc__},
+    {"arc_raw_size", arcstat_raw_size__doc__},
+    {"cached_only_in_progress", arcstat_cached_only_in_progress__doc__},
+    {"abd_chunk_waste_size", arcstat_abd_chunk_waste_size__doc__},
+    {0},
+};
+
+static PyStructSequence_Desc arcstats_desc = {
+    .name = "truenas_pylibzfs.kstat.ArcStats",
+    .doc = "Snapshot of ZFS ARC (Adaptive Replacement Cache) statistics "
+           "read from " ARCSTATS_PATH ".",
+    .fields = arcstats_fields,
+    .n_in_sequence = ARCSTATS_N_FIELDS,
+};
+
+static int
+init_arcstats_type(PyObject *module)
+{
+    pyzfs_kstat_state_t *state = NULL;
+    PyTypeObject *tp = NULL;
+
+    state = (pyzfs_kstat_state_t *)PyModule_GetState(module);
+
+    tp = PyStructSequence_NewType(&arcstats_desc);
+    if (tp == NULL)
+        return -1;
+
+    state->arcstats_type = tp;
+
+    return PyModule_AddObjectRef(module, "ArcStats", (PyObject *)tp);
+}
+
+/* -------------------------------------------------------------------------
+ * Module method docstrings and table
+ * ------------------------------------------------------------------------- */
+
+PyDoc_STRVAR(py_get_arcstats__doc__,
+"get_arcstats() -> ArcStats\n"
+"--------------------------\n\n"
+"Read and return a snapshot of ZFS ARC (Adaptive Replacement Cache)\n"
+"statistics from " ARCSTATS_PATH ".\n"
+"\n"
+"Each call opens and reads the file, so successive calls return\n"
+"independent snapshots reflecting the current kernel state.\n"
+"\n"
+"Returns\n"
+"-------\n"
+"ArcStats\n"
+"    Named struct sequence with one integer field per ARC statistic.\n"
+"    Fields are accessible by name (stats.hits) or by index (stats[0]).\n"
+"    The single signed field is memory_available_bytes; all others are\n"
+"    unsigned.\n"
+"\n"
+"Raises\n"
+"------\n"
+"OSError\n"
+"    " ARCSTATS_PATH " could not be opened.\n"
+"ValueError\n"
+"    " ARCSTATS_PATH " has an unexpected format or field count.\n"
+"    This indicates a ZFS version mismatch; update arcstats.c and stubs.\n");
+
+static PyMethodDef pyzfs_kstat_methods[] = {
+    {
+        "get_arcstats",
+        py_get_arcstats,
+        METH_NOARGS,
+        py_get_arcstats__doc__,
+    },
+    {NULL, NULL, 0, NULL},
+};
+
+/* -------------------------------------------------------------------------
+ * Module definition and init
+ * ------------------------------------------------------------------------- */
+
+PyDoc_STRVAR(pyzfs_kstat_module__doc__,
+"truenas_pylibzfs.kstat -- ZFS kernel statistics (kstat) reader.\n\n"
+"Provides access to ZFS kernel statistics exposed via the SPL\n"
+"(Solaris Porting Layer) kstat interface under /proc/spl/kstat/zfs/.\n"
+"No libzfs dependency; reads directly from /proc.\n");
+
+static struct PyModuleDef pyzfs_kstat_module = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "truenas_pylibzfs.kstat",
+    .m_doc = pyzfs_kstat_module__doc__,
+    .m_size = sizeof(pyzfs_kstat_state_t),
+    .m_methods = pyzfs_kstat_methods,
+};
+
+PyObject *
+py_setup_kstat_module(PyObject *parent)
+{
+    PyObject *m = NULL;
+
+    m = PyModule_Create(&pyzfs_kstat_module);
+    if (m == NULL)
+        return NULL;
+
+    if (init_arcstats_type(m) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+
+    return m;
+}

--- a/src/pyzfs_kstat/pyzfs_kstat.h
+++ b/src/pyzfs_kstat/pyzfs_kstat.h
@@ -1,0 +1,31 @@
+#ifndef _PYZFS_KSTAT_H
+#define _PYZFS_KSTAT_H
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+/*
+ * Path to the ARC (Adaptive Replacement Cache) kstat file exposed by
+ * the SPL (Solaris Porting Layer) kernel module.
+ */
+#define ARCSTATS_PATH "/proc/spl/kstat/zfs/arcstats"
+
+/*
+ * Number of data fields in ARCSTATS_PATH.
+ *
+ * Derived from arc_stats_t in include/sys/arc_impl.h in the ZFS source tree,
+ * excluding the COMPAT_FREEBSD11-only "other_size" field which is not present
+ * on Linux.
+ *
+ * This constant must stay in sync with ARCSTATS_PATH. The test
+ * tests/test_kstat_arcstats.py enforces that invariant in CI.
+ */
+#define ARCSTATS_N_FIELDS 147
+
+typedef struct {
+    PyTypeObject *arcstats_type;
+} pyzfs_kstat_state_t;
+
+extern PyObject *py_get_arcstats(PyObject *module, PyObject *args);
+
+#endif /* _PYZFS_KSTAT_H */

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -527,6 +527,7 @@ PyInit_truenas_pylibzfs(void)
 	PyObject *constants = NULL;
 	PyObject *libzfs_types = NULL;
 	PyObject *lzc = NULL;
+	PyObject *kstat = NULL;
 	PyObject *propsets = NULL;
 	int err;
 
@@ -592,6 +593,14 @@ PyInit_truenas_pylibzfs(void)
 	propsets = py_setup_propset_module(mpylibzfs);
 	err = PyModule_AddObjectRef(mpylibzfs, "property_sets", propsets);
 	Py_XDECREF(propsets);
+	if (err) {
+		Py_DECREF(mpylibzfs);
+		return NULL;
+	}
+
+	kstat = py_setup_kstat_module(mpylibzfs);
+	err = PyModule_AddObjectRef(mpylibzfs, "kstat", kstat);
+	Py_XDECREF(kstat);
 	if (err) {
 		Py_DECREF(mpylibzfs);
 		return NULL;

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -571,6 +571,9 @@ extern PyObject *py_zfs_promote(py_zfs_obj_t *obj);
 /* Set up propset module with frozensets */
 extern PyObject *py_setup_propset_module(PyObject *parent);
 
+/* Set up kstat submodule (provided by pyzfs_kstat/pyzfs_kstat.c) */
+extern PyObject *py_setup_kstat_module(PyObject *parent);
+
 /* Provided by nvlist_utils.c, nvlist_utils_nvl_to_dict.c,
  * and nvlist_utils_dict_to_nvl.c */
 extern PyObject *user_props_nvlist_to_py_dict(nvlist_t *userprops);

--- a/stubs/kstat.pyi
+++ b/stubs/kstat.pyi
@@ -1,0 +1,461 @@
+from typing import Any, ClassVar, Self, final
+
+
+@final
+class ArcStats:
+    """Snapshot of ZFS ARC (Adaptive Replacement Cache) statistics
+    read from /proc/spl/kstat/zfs/arcstats.
+    """
+
+    # Aggregate hit/miss counters
+    hits: int
+    """ARC requests satisfied from cache without I/O (sum of all demand and
+    prefetch, data and metadata hits)."""
+    iohits: int
+    """ARC requests for which the required data was already being fetched by
+    in-progress I/O at the time of the request."""
+    misses: int
+    """ARC requests that required issuing new I/O (cache miss)."""
+
+    # Demand data
+    demand_data_hits: int
+    """Demand data requests satisfied from the ARC without I/O."""
+    demand_data_iohits: int
+    """Demand data requests whose data was already being fetched by
+    in-progress I/O."""
+    demand_data_misses: int
+    """Demand data requests that required new I/O (cache miss)."""
+
+    # Demand metadata
+    demand_metadata_hits: int
+    """Demand metadata requests satisfied from the ARC without I/O."""
+    demand_metadata_iohits: int
+    """Demand metadata requests whose data was already being fetched by
+    in-progress I/O."""
+    demand_metadata_misses: int
+    """Demand metadata requests that required new I/O (cache miss)."""
+
+    # Prefetch data
+    prefetch_data_hits: int
+    """Prefetch data requests satisfied from the ARC without I/O."""
+    prefetch_data_iohits: int
+    """Prefetch data requests whose data was already being fetched by
+    in-progress I/O."""
+    prefetch_data_misses: int
+    """Prefetch data requests that required new I/O (cache miss)."""
+
+    # Prefetch metadata
+    prefetch_metadata_hits: int
+    """Prefetch metadata requests satisfied from the ARC without I/O."""
+    prefetch_metadata_iohits: int
+    """Prefetch metadata requests whose data was already being fetched by
+    in-progress I/O."""
+    prefetch_metadata_misses: int
+    """Prefetch metadata requests that required new I/O (cache miss)."""
+
+    # ARC state hits
+    mru_hits: int
+    """ARC hits on buffers in the MRU (Most Recently Used) state."""
+    mru_ghost_hits: int
+    """ARC hits on the MRU ghost list. Ghost entries track recently evicted
+    MRU buffers to bias re-admission toward MRU on the next access."""
+    mfu_hits: int
+    """ARC hits on buffers in the MFU (Most Frequently Used) state."""
+    mfu_ghost_hits: int
+    """ARC hits on the MFU ghost list. Ghost entries track recently evicted
+    MFU buffers to bias re-admission toward MFU on the next access."""
+    uncached_hits: int
+    """ARC hits on buffers marked ARC_FLAG_UNCACHED (scheduled for eviction
+    on the next opportunity)."""
+    deleted: int
+    """ARC buffers deleted (freed) from the cache."""
+
+    # Eviction
+    mutex_miss: int
+    """Evictions skipped because the buffer's hash lock was held by another
+    thread. Hash locks are shared across multiple buffers so contention
+    may not involve the target buffer."""
+    access_skip: int
+    """Buffers skipped during access state update because the header was
+    released after the hash lock was acquired."""
+    evict_skip: int
+    """Buffers skipped during eviction because they had I/O in progress,
+    were indirect prefetch buffers that had not lived long enough, or
+    belonged to a different pool."""
+    evict_not_enough: int
+    """Times arc_evict_state() could not evict enough buffers to reach its
+    target amount."""
+    evict_l2_cached: int
+    """Bytes evicted from ARC that were already cached on an L2ARC device."""
+    evict_l2_eligible: int
+    """Bytes evicted from ARC that were eligible for caching on L2ARC."""
+    evict_l2_eligible_mfu: int
+    """MFU bytes evicted from ARC that were eligible for L2ARC caching."""
+    evict_l2_eligible_mru: int
+    """MRU bytes evicted from ARC that were eligible for L2ARC caching."""
+    evict_l2_ineligible: int
+    """Bytes evicted from ARC that were ineligible for L2ARC caching
+    (e.g. encrypted data or data that is already on L2ARC)."""
+    evict_l2_skip: int
+    """ARC evictions for which the L2ARC write was skipped."""
+
+    # Hash table
+    hash_elements: int
+    """Current number of elements in the ARC hash table."""
+    hash_elements_max: int
+    """Peak number of elements ever resident in the ARC hash table."""
+    hash_collisions: int
+    """Total number of hash collisions recorded in the ARC hash table."""
+    hash_chains: int
+    """Number of hash chains (buckets with more than one element) in the
+    ARC hash table."""
+    hash_chain_max: int
+    """Length of the longest hash chain ever observed in the ARC hash table."""
+
+    # Cache size targets (bytes)
+    meta: int
+    """ARC metadata limit in bytes (arc_meta_limit). Metadata consumption
+    above this target triggers eviction of metadata buffers."""
+    pd: int
+    """ARC prefetch data target size in bytes."""
+    pm: int
+    """ARC prefetch metadata target size in bytes."""
+    c: int
+    """Current ARC target size in bytes. The ARC grows toward arc_c_max and
+    shrinks toward arc_c_min in response to memory pressure."""
+    c_min: int
+    """Minimum ARC target size in bytes (arc_c_min). The ARC will not shrink
+    below this value."""
+    c_max: int
+    """Maximum ARC target size in bytes (arc_c_max). The ARC will not grow
+    beyond this value."""
+
+    # Overall size (bytes)
+    size: int
+    """Total size of all ARC-cached buffers in bytes."""
+    compressed_size: int
+    """Compressed size in bytes of data stored in arc_buf_hdr_t b_pabd
+    fields. Equals uncompressed_size when compressed ARC is disabled."""
+    uncompressed_size: int
+    """Uncompressed size in bytes of data stored in arc_buf_hdr_t b_pabd
+    fields. Equals compressed_size when compressed ARC is disabled."""
+    overhead_size: int
+    """Bytes held in short-lived uncompressed arc_buf_t copies attached to
+    headers. These copies are evicted when unreferenced unless
+    zfs_keep_uncompressed_metadata or zfs_keep_uncompressed_level is set."""
+    hdr_size: int
+    """Bytes consumed by internal ARC tracking structures (arc_buf_hdr_t and
+    arc_buf_t objects). These structures are not backed by ARC data buffers."""
+    data_size: int
+    """Bytes consumed by ARC_BUFC_DATA buffers, which back on-disk user
+    data such as plain file contents."""
+    metadata_size: int
+    """Bytes consumed by ARC_BUFC_METADATA buffers, which back internal ZFS
+    structures such as ZAP objects, dnodes, and indirect blocks."""
+    dbuf_size: int
+    """Bytes consumed by dmu_buf_impl_t (dbuf) objects."""
+    dnode_size: int
+    """Bytes consumed by dnode_t objects."""
+    bonus_size: int
+    """Bytes consumed by dnode bonus buffers."""
+
+    # Anon state (bytes)
+    anon_size: int
+    """Total bytes in the arc_anon state. Anon buffers are newly allocated
+    and have not yet been promoted to MRU or MFU."""
+    anon_data: int
+    """ARC_BUFC_DATA bytes in the arc_anon state."""
+    anon_metadata: int
+    """ARC_BUFC_METADATA bytes in the arc_anon state."""
+    anon_evictable_data: int
+    """Evictable ARC_BUFC_DATA bytes in the arc_anon state
+    (no outstanding holds on the buffer)."""
+    anon_evictable_metadata: int
+    """Evictable ARC_BUFC_METADATA bytes in the arc_anon state
+    (no outstanding holds on the buffer)."""
+
+    # MRU state (bytes)
+    mru_size: int
+    """Total bytes in the MRU (Most Recently Used) state, including data,
+    metadata, evictable, and pinned buffers."""
+    mru_data: int
+    """ARC_BUFC_DATA bytes in the MRU state."""
+    mru_metadata: int
+    """ARC_BUFC_METADATA bytes in the MRU state."""
+    mru_evictable_data: int
+    """Evictable ARC_BUFC_DATA bytes in the MRU state
+    (no outstanding holds on the buffer)."""
+    mru_evictable_metadata: int
+    """Evictable ARC_BUFC_METADATA bytes in the MRU state
+    (no outstanding holds on the buffer)."""
+
+    # MRU ghost state (bytes) -- notional, no actual buffers
+    mru_ghost_size: int
+    """Notional bytes tracked by MRU ghost headers. Ghost lists hold only
+    headers with no associated data buffers; this value represents what
+    those buffers would have consumed had they remained cached."""
+    mru_ghost_data: int
+    """Notional ARC_BUFC_DATA bytes tracked by MRU ghost headers."""
+    mru_ghost_metadata: int
+    """Notional ARC_BUFC_METADATA bytes tracked by MRU ghost headers."""
+    mru_ghost_evictable_data: int
+    """Notional evictable ARC_BUFC_DATA bytes on the MRU ghost list."""
+    mru_ghost_evictable_metadata: int
+    """Notional evictable ARC_BUFC_METADATA bytes on the MRU ghost list."""
+
+    # MFU state (bytes)
+    mfu_size: int
+    """Total bytes in the MFU (Most Frequently Used) state, including data,
+    metadata, evictable, and pinned buffers."""
+    mfu_data: int
+    """ARC_BUFC_DATA bytes in the MFU state."""
+    mfu_metadata: int
+    """ARC_BUFC_METADATA bytes in the MFU state."""
+    mfu_evictable_data: int
+    """Evictable ARC_BUFC_DATA bytes in the MFU state
+    (no outstanding holds on the buffer)."""
+    mfu_evictable_metadata: int
+    """Evictable ARC_BUFC_METADATA bytes in the MFU state
+    (no outstanding holds on the buffer)."""
+
+    # MFU ghost state (bytes) -- notional, no actual buffers
+    mfu_ghost_size: int
+    """Notional bytes tracked by MFU ghost headers.
+    See mru_ghost_size for a full description of ghost lists."""
+    mfu_ghost_data: int
+    """Notional ARC_BUFC_DATA bytes tracked by MFU ghost headers."""
+    mfu_ghost_metadata: int
+    """Notional ARC_BUFC_METADATA bytes tracked by MFU ghost headers."""
+    mfu_ghost_evictable_data: int
+    """Notional evictable ARC_BUFC_DATA bytes on the MFU ghost list."""
+    mfu_ghost_evictable_metadata: int
+    """Notional evictable ARC_BUFC_METADATA bytes on the MFU ghost list."""
+
+    # Uncached state (bytes)
+    uncached_size: int
+    """Total bytes pending eviction from ARC because ARC_FLAG_UNCACHED is
+    set. These buffers will be freed on the next eviction pass."""
+    uncached_data: int
+    """ARC_BUFC_DATA bytes pending eviction due to ARC_FLAG_UNCACHED."""
+    uncached_metadata: int
+    """ARC_BUFC_METADATA bytes pending eviction due to ARC_FLAG_UNCACHED."""
+    uncached_evictable_data: int
+    """Evictable ARC_BUFC_DATA bytes pending eviction due to ARC_FLAG_UNCACHED
+    (no outstanding holds on the buffer)."""
+    uncached_evictable_metadata: int
+    """Evictable ARC_BUFC_METADATA bytes pending eviction due to
+    ARC_FLAG_UNCACHED (no outstanding holds on the buffer)."""
+
+    # L2ARC (Level 2 ARC cache device)
+    l2_hits: int
+    """L2ARC (Level 2 ARC cache device) read hits."""
+    l2_misses: int
+    """L2ARC read misses (data not found in L2ARC; fell through to disk)."""
+
+    # L2ARC sizes by ARC state (bytes)
+    l2_prefetch_asize: int
+    """Allocated bytes of L2ARC-cached buffers originating from the prefetch
+    ARC state."""
+    l2_mru_asize: int
+    """Allocated bytes of L2ARC-cached buffers originating from the MRU state."""
+    l2_mfu_asize: int
+    """Allocated bytes of L2ARC-cached buffers originating from the MFU state."""
+
+    # L2ARC sizes by content type (bytes)
+    l2_bufc_data_asize: int
+    """Allocated bytes of L2ARC-cached ARC_BUFC_DATA buffers."""
+    l2_bufc_metadata_asize: int
+    """Allocated bytes of L2ARC-cached ARC_BUFC_METADATA buffers."""
+
+    # L2ARC I/O
+    l2_feeds: int
+    """Number of ARC header batches (feeds) sent to L2ARC for writing."""
+    l2_rw_clash: int
+    """ARC evictions skipped because an L2ARC write was in progress on the
+    buffer at the time of eviction."""
+    l2_read_bytes: int
+    """Total bytes read from L2ARC devices."""
+    l2_write_bytes: int
+    """Total bytes written to L2ARC devices."""
+    l2_writes_sent: int
+    """L2ARC write I/Os issued."""
+    l2_writes_done: int
+    """L2ARC write I/Os completed successfully."""
+    l2_writes_error: int
+    """L2ARC write I/Os that completed with errors."""
+    l2_writes_lock_retry: int
+    """L2ARC write attempts that had to retry due to lock contention."""
+    l2_evict_lock_retry: int
+    """L2ARC eviction attempts that had to retry due to lock contention."""
+    l2_evict_reading: int
+    """L2ARC buffers skipped for eviction because a read was in progress on
+    the buffer."""
+    l2_evict_l1cached: int
+    """L2ARC buffers evicted from L2ARC that were still present in L1 ARC."""
+    l2_free_on_write: int
+    """L2ARC buffers queued to be freed on the next L2ARC write."""
+    l2_abort_lowmem: int
+    """L2ARC write passes aborted because system memory was too low to
+    proceed safely."""
+    l2_cksum_bad: int
+    """L2ARC reads that failed due to a checksum mismatch."""
+    l2_io_error: int
+    """L2ARC reads that failed due to an I/O error."""
+    l2_size: int
+    """Logical (uncompressed) size in bytes of all data currently cached on
+    L2ARC devices."""
+    l2_asize: int
+    """Actual (compressed, device-aligned) size in bytes of all data currently
+    stored on L2ARC devices."""
+    l2_hdr_size: int
+    """Bytes consumed by L2ARC buffer header structures resident in L1 ARC
+    memory."""
+
+    # L2ARC log blocks (persistent L2ARC rebuild)
+    l2_log_blk_writes: int
+    """Number of L2ARC log blocks written. Log blocks record which ARC buffers
+    are stored on L2ARC and enable the cache to be rebuilt after a pool
+    import without re-reading all data from disk."""
+    l2_log_blk_avg_asize: int
+    """Moving average of the aligned size in bytes of L2ARC log blocks.
+    Updated during L2ARC rebuild and during log block writes."""
+    l2_log_blk_asize: int
+    """Total aligned size in bytes of all L2ARC log blocks currently on
+    L2ARC devices."""
+    l2_log_blk_count: int
+    """Number of L2ARC log blocks currently present on L2ARC devices."""
+    l2_data_to_meta_ratio: int
+    """Moving average ratio of restored L2ARC data size to the aligned size
+    of its log metadata. Updated during L2ARC rebuild and log block writes."""
+
+    # L2ARC rebuild
+    l2_rebuild_success: int
+    """Number of L2ARC devices for which log-based rebuild completed
+    successfully on pool import."""
+    l2_rebuild_unsupported: int
+    """L2ARC rebuild attempts aborted because the device header was in an
+    unsupported format or was corrupted."""
+    l2_rebuild_io_errors: int
+    """L2ARC rebuild attempts aborted due to I/O errors while reading a log
+    block."""
+    l2_rebuild_dh_errors: int
+    """L2ARC rebuild attempts aborted due to I/O errors while reading the
+    device header."""
+    l2_rebuild_cksum_lb_errors: int
+    """L2ARC log blocks skipped during rebuild due to checksum errors."""
+    l2_rebuild_lowmem: int
+    """L2ARC rebuild attempts aborted because system memory was too low."""
+    l2_rebuild_size: int
+    """Logical size in bytes of L2ARC data restored during the last rebuild."""
+    l2_rebuild_asize: int
+    """Aligned (on-device) size in bytes of L2ARC data restored during the
+    last rebuild."""
+    l2_rebuild_bufs: int
+    """Number of L2ARC log entries (buffers) successfully restored to ARC
+    during rebuild."""
+    l2_rebuild_bufs_precached: int
+    """Number of L2ARC log entries skipped during rebuild because those
+    buffers were already cached in L1 ARC."""
+    l2_rebuild_log_blks: int
+    """Number of L2ARC log blocks successfully read during rebuild. Each log
+    block may describe up to L2ARC_LOG_BLK_MAX_ENTRIES buffers."""
+
+    # Memory
+    memory_throttle_count: int
+    """Number of times ARC was asked to shrink in response to memory pressure
+    (throttle events triggered by the kernel reclaim path)."""
+    memory_direct_count: int
+    """Number of direct memory reclaim events where the ARC shrank
+    synchronously to satisfy memory pressure."""
+    memory_indirect_count: int
+    """Number of indirect memory reclaim events where the ARC shrank
+    asynchronously in response to memory pressure."""
+    memory_all_bytes: int
+    """Total system memory in bytes as reported to the ARC."""
+    memory_free_bytes: int
+    """Free system memory in bytes as reported to the ARC."""
+    memory_available_bytes: int
+    """Estimated memory in bytes currently available for ARC growth.
+    Signed value (KSTAT_DATA_INT64); may be negative under sustained
+    memory pressure when the ARC owes memory back to the system."""
+
+    # ARC control and state
+    arc_no_grow: int
+    """Non-zero when the ARC is suppressing growth due to memory pressure."""
+    arc_tempreserve: int
+    """Bytes temporarily reserved in the ARC for in-progress dirty data
+    writes. Released when the write completes."""
+    arc_loaned_bytes: int
+    """Bytes loaned from the ARC to other kernel subsystems (e.g. for
+    zero-copy I/O staging). Counted against the ARC size target."""
+    arc_prune: int
+    """Number of times the ARC requested that registered subsystems release
+    memory via prune callbacks."""
+    arc_meta_used: int
+    """Total ARC bytes consumed by metadata: sum of hdr_size, metadata_size,
+    dbuf_size, dnode_size, and bonus_size."""
+    arc_dnode_limit: int
+    """Target upper bound in bytes for dnode_size within the ARC. Dnode
+    eviction is triggered when dnode_size approaches this limit."""
+
+    # Prefetch
+    async_upgrade_sync: int
+    """Async prefetch requests that were upgraded to synchronous because a
+    demand read arrived before the prefetch completed."""
+    predictive_prefetch: int
+    """Predictive prefetch requests issued. Predictive prefetch detects
+    sequential access patterns and fetches data ahead of demand."""
+    demand_hit_predictive_prefetch: int
+    """Demand reads satisfied by a predictive prefetch that had already
+    completed (prefetch was useful)."""
+    demand_iohit_predictive_prefetch: int
+    """Demand reads that found a predictive prefetch already in progress
+    (overlapping prefetch and demand I/O)."""
+    prescient_prefetch: int
+    """Prescient prefetch requests issued. Prescient prefetch uses explicit
+    read-ahead hints from upper layers such as dmu_prefetch."""
+    demand_hit_prescient_prefetch: int
+    """Demand reads satisfied by a prescient prefetch that had already
+    completed (prefetch was useful)."""
+    demand_iohit_prescient_prefetch: int
+    """Demand reads that found a prescient prefetch already in progress
+    (overlapping prefetch and demand I/O)."""
+
+    # Miscellaneous
+    arc_need_free: int
+    """Bytes the ARC is currently working to free in order to satisfy
+    outstanding memory pressure requests."""
+    arc_sys_free: int
+    """Free memory target in bytes that the ARC aims to maintain for the
+    rest of the system."""
+    arc_raw_size: int
+    """Bytes of encrypted (raw/ciphertext) data currently cached in the ARC."""
+    cached_only_in_progress: int
+    """Non-zero while a cache-only (dry-run) traversal of the pool is active."""
+    abd_chunk_waste_size: int
+    """Bytes wasted due to ABD (Aggregation Buffer Descriptor) chunk alignment
+    padding. ABDs allocate memory in fixed-size chunks; unused space at the
+    end of the last chunk of each allocation contributes to this counter."""
+
+    __match_args__: ClassVar[tuple[str, ...]]
+    n_fields: ClassVar[int]           # = 147
+    n_sequence_fields: ClassVar[int]  # = 147
+    n_unnamed_fields: ClassVar[int]   # = 0
+    def __replace__(self, **changes: Any) -> Self: ...
+
+
+def get_arcstats() -> ArcStats:
+    """Read and return a snapshot of ZFS ARC statistics.
+
+    Each call opens and reads /proc/spl/kstat/zfs/arcstats, so successive
+    calls return independent snapshots reflecting the current kernel state.
+
+    Raises
+    ------
+    OSError
+        /proc/spl/kstat/zfs/arcstats could not be opened.
+    ValueError
+        /proc/spl/kstat/zfs/arcstats has an unexpected format or field
+        count, indicating a ZFS version mismatch.
+    """
+    ...

--- a/tests/test_kstat_arcstats.py
+++ b/tests/test_kstat_arcstats.py
@@ -1,0 +1,90 @@
+"""
+Verify that the hard-coded ArcStats field list stays in sync with
+/proc/spl/kstat/zfs/arcstats.
+
+This test must run on a host with the ZFS kernel module loaded and must be
+built against the same ZFS source tree used to compile truenas_pylibzfs.
+It is intended to run in the CI environment (GitHub Actions) where the build
+VM has the target ZFS version installed.
+
+If this test fails, the installed ZFS version has added, removed, or
+reordered arcstats fields relative to the hard-coded list in
+src/pyzfs_kstat/arcstats.c and stubs/. Update both files to match.
+"""
+
+import sys
+
+from truenas_pylibzfs import kstat
+
+ARCSTATS_PATH = "/proc/spl/kstat/zfs/arcstats"
+
+
+def _read_proc_fields():
+    """Return the ordered list of field names from ARCSTATS_PATH."""
+    with open(ARCSTATS_PATH) as f:
+        lines = f.readlines()
+    # Line 0: metadata header; line 1: column header; lines 2+: data.
+    return [line.split()[0] for line in lines[2:] if line.strip()]
+
+
+def _arcstats_fields():
+    """
+    Return the ordered field names of the ArcStats struct sequence type.
+
+    PyStructSequence types gained an automatic _fields tuple in Python 3.13.
+    For earlier versions, extract field names from the member descriptors that
+    PyStructSequence_NewType adds to the type dict.
+    """
+    t = type(kstat.get_arcstats())
+    if hasattr(t, '_fields'):
+        return list(t._fields)
+    # Identify the member_descriptor C type via a known PyStructSequence
+    # (sys.version_info), then collect all such descriptors from our type.
+    _mdt = type(type(sys.version_info).__dict__['major'])
+    return [k for k, v in t.__dict__.items() if isinstance(v, _mdt)]
+
+
+def test_arcstats_fields_in_sync():
+    """
+    Field names and order in ArcStats must exactly match ARCSTATS_PATH.
+
+    Checks both the set of names (catches additions and removals) and the
+    order (catches reorderings that would silently mis-assign values).
+    """
+    proc_fields = _read_proc_fields()
+    ext_fields = _arcstats_fields()
+
+    assert ext_fields == proc_fields, (
+        "ArcStats field list is out of sync with {}.\n"
+        "  Only in {}: {}\n"
+        "  Only in extension: {}\n"
+        "  Update src/pyzfs_kstat/arcstats.c (ARCSTATS_N_FIELDS and "
+        "arcstats_fields[]) and stubs/ to match.".format(
+            ARCSTATS_PATH,
+            ARCSTATS_PATH,
+            sorted(set(proc_fields) - set(ext_fields)),
+            sorted(set(ext_fields) - set(proc_fields)),
+        )
+    )
+
+
+def test_arcstats_returns_ints():
+    """All ArcStats field values must be integers."""
+    stats = kstat.get_arcstats()
+    for i, value in enumerate(stats):
+        assert isinstance(value, int), (
+            "ArcStats field {} expected int, got {}".format(i, type(value).__name__)
+        )
+
+
+def test_arcstats_field_count():
+    """ArcStats field count must equal ARCSTATS_N_FIELDS (147)."""
+    stats = kstat.get_arcstats()
+    assert len(stats) == 147
+
+
+def test_arcstats_successive_calls_are_independent():
+    """Two successive get_arcstats() calls must return distinct objects."""
+    a = kstat.get_arcstats()
+    b = kstat.get_arcstats()
+    assert a is not b


### PR DESCRIPTION
This commit adds a new cpython extension with typing to retrieve various module kstats. Currently it is limited to arcsummary, but will be expanded to include ZIL stats as well.

Original PR: https://github.com/truenas/truenas_pylibzfs/pull/231
