### PR TITLE
NAS-140639 / 27.0.0-BETA.1 / Expand kstat submodule to include ZIL stats

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ truenas_pylibzfs = Extension(
         'src/libzfs_core/libzfs_core_replication.c',
         'src/pyzfs_kstat/pyzfs_kstat.c',
         'src/pyzfs_kstat/arcstats.c',
+        'src/pyzfs_kstat/zilstats.c',
     ],
     libraries = [
         'zfs',

--- a/src/pyzfs_kstat/README.md
+++ b/src/pyzfs_kstat/README.md
@@ -10,28 +10,33 @@ dependency on libzfs or any ZFS userland library**. It reads kstat files
 exposed by the ZFS kernel module under `/proc/spl/kstat/zfs/` via standard
 C stdio, making it lightweight and usable without opening a `ZFS` handle.
 
-Currently provides ARC (Adaptive Replacement Cache) statistics via
-`get_arcstats()`. ZIL statistics will follow.
+Currently provides:
+
+- ARC (Adaptive Replacement Cache) statistics via `get_arcstats()` (`/proc/spl/kstat/zfs/arcstats`)
+- ZIL (ZFS Intent Log) statistics via `get_zilstats()` (`/proc/spl/kstat/zfs/zil`)
 
 ## Source files
 
 | File | Purpose |
 |---|---|
 | `pyzfs_kstat.h` | Module state struct, path/field-count constants, extern declarations |
-| `pyzfs_kstat.c` | Module init, `ArcStats` `PyStructSequence` type registration, `PyDoc_STRVAR` field docstrings, method table |
+| `pyzfs_kstat.c` | Module init, `ArcStats` and `ZilStats` `PyStructSequence` type registration, `PyDoc_STRVAR` field docstrings, method table |
 | `arcstats.c` | `get_arcstats()` implementation -- reads and parses `/proc/spl/kstat/zfs/arcstats` |
+| `zilstats.c` | `get_zilstats()` implementation -- reads and parses `/proc/spl/kstat/zfs/zil` |
 
 ## Exposed methods
 
 | Python name | Source | Description |
 |---|---|---|
 | `get_arcstats()` | `arcstats.c` | Returns an `ArcStats` struct sequence with 147 integer fields |
+| `get_zilstats()` | `zilstats.c` | Returns a `ZilStats` struct sequence with 21 integer fields |
 
 ## Exposed types
 
 | Python name | Kind | Description |
 |---|---|---|
 | `ArcStats` | `PyStructSequence` | Named tuple-like object with one field per ARC kstat counter |
+| `ZilStats` | `PyStructSequence` | Named tuple-like object with one field per ZIL kstat counter |
 
 ## Developer notes
 

--- a/src/pyzfs_kstat/pyzfs_kstat.c
+++ b/src/pyzfs_kstat/pyzfs_kstat.c
@@ -1,15 +1,18 @@
 #include "pyzfs_kstat.h"
 
 /*
- * truenas_pylibzfs.kstat -- ArcStats field docstrings and struct sequence
- * definition.
+ * truenas_pylibzfs.kstat -- ArcStats and ZilStats field docstrings and
+ * struct sequence definitions.
  *
- * All PyDoc_STRVAR definitions for ArcStats fields live here, not in
- * arcstats.c. arcstats.c contains only the file-parsing implementation.
+ * All PyDoc_STRVAR definitions for kstat fields live here, not in the
+ * per-kstat implementation files (arcstats.c, zilstats.c), which contain
+ * only file-parsing logic.
  *
  * Field names and documentation are derived from:
- *   module/zfs/arc.c       -- authoritative kstat name list
- *   include/sys/arc_impl.h -- per-field comments
+ *   module/zfs/arc.c       -- ARC kstat name list
+ *   include/sys/arc_impl.h -- ARC per-field comments
+ *   module/zfs/zil.c       -- ZIL kstat name list
+ *   include/sys/zil.h      -- ZIL per-field comments
  * in the ZFS source tree (github.com/truenas/zfs,
  * branch truenas/zfs-2.4-release).
  */
@@ -777,6 +780,163 @@ init_arcstats_type(PyObject *module)
 }
 
 /* -------------------------------------------------------------------------
+ * ZilStats field docstrings
+ *
+ * Field order must match the zil_stats initializer in module/zfs/zil.c
+ * (lines 101-123 in the ZFS source tree).
+ * ------------------------------------------------------------------------- */
+
+/* Commit counters */
+
+PyDoc_STRVAR(zilstat_commit_count__doc__,
+"Number of times a ZIL (ZFS Intent Log) commit (e.g. fsync) has been "
+"requested.");
+
+PyDoc_STRVAR(zilstat_commit_writer_count__doc__,
+"Number of times the ZIL has been flushed to stable storage. This is "
+"less than zil_commit_count when commits are merged.");
+
+PyDoc_STRVAR(zilstat_commit_error_count__doc__,
+"ZIL commits that failed due to an I/O error during write or flush, "
+"forcing a fallback to txg_wait_synced().");
+
+PyDoc_STRVAR(zilstat_commit_stall_count__doc__,
+"ZIL commits that stalled because LWB (Log Write Block) allocation "
+"failed and the ZIL chain was abandoned, forcing a fallback to "
+"txg_wait_synced().");
+
+PyDoc_STRVAR(zilstat_commit_suspend_count__doc__,
+"ZIL commits that failed because the ZIL was suspended, forcing a "
+"fallback to txg_wait_synced().");
+
+PyDoc_STRVAR(zilstat_commit_crash_count__doc__,
+"ZIL commits that failed because the ZIL crashed, forcing a fallback "
+"to txg_wait_synced().");
+
+/* Intent transaction (itx) counters */
+
+PyDoc_STRVAR(zilstat_itx_count__doc__,
+"Total number of intent transactions (reads, writes, renames, etc.) "
+"committed to the ZIL.");
+
+PyDoc_STRVAR(zilstat_itx_indirect_count__doc__,
+"Transactions written using indirect mode (WR_INDIRECT): data is written "
+"directly to the pool via dmu_sync() and a block pointer is stored in the "
+"log record instead of the data itself.");
+
+PyDoc_STRVAR(zilstat_itx_indirect_bytes__doc__,
+"Bytes of transaction data written using indirect mode. Accumulates the "
+"logical data length, not the log record size.");
+
+PyDoc_STRVAR(zilstat_itx_copied_count__doc__,
+"Transactions written using immediate-copy mode (WR_COPIED): data is "
+"copied directly into the log record at commit time because the "
+"transaction was synchronous (O_SYNC or O_DSYNC).");
+
+PyDoc_STRVAR(zilstat_itx_copied_bytes__doc__,
+"Bytes of transaction data written using immediate-copy mode.");
+
+PyDoc_STRVAR(zilstat_itx_needcopy_count__doc__,
+"Transactions written using deferred-copy mode (WR_NEED_COPY): data is "
+"retrieved from the DMU (Data Management Unit) and copied into the log "
+"record only if the write needs to be flushed.");
+
+PyDoc_STRVAR(zilstat_itx_needcopy_bytes__doc__,
+"Bytes of transaction data written using deferred-copy mode.");
+
+/* Normal pool metaslab */
+
+PyDoc_STRVAR(zilstat_itx_metaslab_normal_count__doc__,
+"Transactions allocated to the normal (non-slog) storage pool.");
+
+PyDoc_STRVAR(zilstat_itx_metaslab_normal_bytes__doc__,
+"Log record bytes allocated to the normal pool. Accumulates actual "
+"log record sizes, which exclude data for indirect writes. "
+"Invariant: bytes <= write <= alloc.");
+
+PyDoc_STRVAR(zilstat_itx_metaslab_normal_write__doc__,
+"Bytes written to the normal pool for ZIL log blocks.");
+
+PyDoc_STRVAR(zilstat_itx_metaslab_normal_alloc__doc__,
+"Bytes allocated from the normal pool for ZIL log blocks.");
+
+/* Slog (Separate Intent Log) metaslab */
+
+PyDoc_STRVAR(zilstat_itx_metaslab_slog_count__doc__,
+"Transactions allocated to the slog (Separate Intent Log) device. "
+"If no dedicated log device is configured, slog statistics remain "
+"zero and all activity is counted under the normal pool.");
+
+PyDoc_STRVAR(zilstat_itx_metaslab_slog_bytes__doc__,
+"Log record bytes allocated to the slog device. "
+"Invariant: bytes <= write <= alloc.");
+
+PyDoc_STRVAR(zilstat_itx_metaslab_slog_write__doc__,
+"Bytes written to the slog device for ZIL log blocks.");
+
+PyDoc_STRVAR(zilstat_itx_metaslab_slog_alloc__doc__,
+"Bytes allocated from the slog device for ZIL log blocks.");
+
+/* -------------------------------------------------------------------------
+ * ZilStats struct sequence definition
+ *
+ * Field order must match the zil_stats initializer in module/zfs/zil.c.
+ *
+ * The test tests/test_kstat_zilstats.py verifies this order against the
+ * live ZILSTATS_PATH file in CI.
+ * ------------------------------------------------------------------------- */
+
+static PyStructSequence_Field zilstats_fields[] = {
+    {"zil_commit_count", zilstat_commit_count__doc__},
+    {"zil_commit_writer_count", zilstat_commit_writer_count__doc__},
+    {"zil_commit_error_count", zilstat_commit_error_count__doc__},
+    {"zil_commit_stall_count", zilstat_commit_stall_count__doc__},
+    {"zil_commit_suspend_count", zilstat_commit_suspend_count__doc__},
+    {"zil_commit_crash_count", zilstat_commit_crash_count__doc__},
+    {"zil_itx_count", zilstat_itx_count__doc__},
+    {"zil_itx_indirect_count", zilstat_itx_indirect_count__doc__},
+    {"zil_itx_indirect_bytes", zilstat_itx_indirect_bytes__doc__},
+    {"zil_itx_copied_count", zilstat_itx_copied_count__doc__},
+    {"zil_itx_copied_bytes", zilstat_itx_copied_bytes__doc__},
+    {"zil_itx_needcopy_count", zilstat_itx_needcopy_count__doc__},
+    {"zil_itx_needcopy_bytes", zilstat_itx_needcopy_bytes__doc__},
+    {"zil_itx_metaslab_normal_count", zilstat_itx_metaslab_normal_count__doc__},
+    {"zil_itx_metaslab_normal_bytes", zilstat_itx_metaslab_normal_bytes__doc__},
+    {"zil_itx_metaslab_normal_write", zilstat_itx_metaslab_normal_write__doc__},
+    {"zil_itx_metaslab_normal_alloc", zilstat_itx_metaslab_normal_alloc__doc__},
+    {"zil_itx_metaslab_slog_count", zilstat_itx_metaslab_slog_count__doc__},
+    {"zil_itx_metaslab_slog_bytes", zilstat_itx_metaslab_slog_bytes__doc__},
+    {"zil_itx_metaslab_slog_write", zilstat_itx_metaslab_slog_write__doc__},
+    {"zil_itx_metaslab_slog_alloc", zilstat_itx_metaslab_slog_alloc__doc__},
+    {0},
+};
+
+static PyStructSequence_Desc zilstats_desc = {
+    .name = "truenas_pylibzfs.kstat.ZilStats",
+    .doc = "Snapshot of ZFS ZIL (ZFS Intent Log) statistics "
+           "read from " ZILSTATS_PATH ".",
+    .fields = zilstats_fields,
+    .n_in_sequence = ZILSTATS_N_FIELDS,
+};
+
+static int
+init_zilstats_type(PyObject *module)
+{
+    pyzfs_kstat_state_t *state = NULL;
+    PyTypeObject *tp = NULL;
+
+    state = (pyzfs_kstat_state_t *)PyModule_GetState(module);
+
+    tp = PyStructSequence_NewType(&zilstats_desc);
+    if (tp == NULL)
+        return -1;
+
+    state->zilstats_type = tp;
+
+    return PyModule_AddObjectRef(module, "ZilStats", (PyObject *)tp);
+}
+
+/* -------------------------------------------------------------------------
  * Module method docstrings and table
  * ------------------------------------------------------------------------- */
 
@@ -805,12 +965,42 @@ PyDoc_STRVAR(py_get_arcstats__doc__,
 "    " ARCSTATS_PATH " has an unexpected format or field count.\n"
 "    This indicates a ZFS version mismatch; update arcstats.c and stubs.\n");
 
+PyDoc_STRVAR(py_get_zilstats__doc__,
+"get_zilstats() -> ZilStats\n"
+"--------------------------\n\n"
+"Read and return a snapshot of ZFS ZIL (ZFS Intent Log) statistics\n"
+"from " ZILSTATS_PATH ".\n"
+"\n"
+"Each call opens and reads the file, so successive calls return\n"
+"independent snapshots reflecting the current kernel state.\n"
+"\n"
+"Returns\n"
+"-------\n"
+"ZilStats\n"
+"    Named struct sequence with one integer field per ZIL statistic.\n"
+"    Fields are accessible by name (stats.zil_commit_count) or by\n"
+"    index (stats[0]). All fields are unsigned.\n"
+"\n"
+"Raises\n"
+"------\n"
+"OSError\n"
+"    " ZILSTATS_PATH " could not be opened.\n"
+"ValueError\n"
+"    " ZILSTATS_PATH " has an unexpected format or field count.\n"
+"    This indicates a ZFS version mismatch; update zilstats.c and stubs.\n");
+
 static PyMethodDef pyzfs_kstat_methods[] = {
     {
         "get_arcstats",
         py_get_arcstats,
         METH_NOARGS,
         py_get_arcstats__doc__,
+    },
+    {
+        "get_zilstats",
+        py_get_zilstats,
+        METH_NOARGS,
+        py_get_zilstats__doc__,
     },
     {NULL, NULL, 0, NULL},
 };
@@ -843,6 +1033,11 @@ py_setup_kstat_module(PyObject *parent)
         return NULL;
 
     if (init_arcstats_type(m) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+
+    if (init_zilstats_type(m) < 0) {
         Py_DECREF(m);
         return NULL;
     }

--- a/src/pyzfs_kstat/pyzfs_kstat.h
+++ b/src/pyzfs_kstat/pyzfs_kstat.h
@@ -22,10 +22,29 @@
  */
 #define ARCSTATS_N_FIELDS 147
 
+/*
+ * Path to the ZIL (ZFS Intent Log) kstat file exposed by the ZFS
+ * kernel module.
+ */
+#define ZILSTATS_PATH "/proc/spl/kstat/zfs/zil"
+
+/*
+ * Number of data fields in ZILSTATS_PATH.
+ *
+ * Derived from zil_kstat_values_t in include/sys/zil.h in the ZFS source
+ * tree.
+ *
+ * This constant must stay in sync with ZILSTATS_PATH. The test
+ * tests/test_kstat_zilstats.py enforces that invariant in CI.
+ */
+#define ZILSTATS_N_FIELDS 21
+
 typedef struct {
     PyTypeObject *arcstats_type;
+    PyTypeObject *zilstats_type;
 } pyzfs_kstat_state_t;
 
 extern PyObject *py_get_arcstats(PyObject *module, PyObject *args);
+extern PyObject *py_get_zilstats(PyObject *module, PyObject *args);
 
 #endif /* _PYZFS_KSTAT_H */

--- a/src/pyzfs_kstat/zilstats.c
+++ b/src/pyzfs_kstat/zilstats.c
@@ -1,0 +1,114 @@
+#include "pyzfs_kstat.h"
+
+#include <stdio.h>
+
+/*
+ * get_zilstats() implementation.
+ *
+ * Reads ZILSTATS_PATH and populates a ZilStats struct sequence whose type
+ * was created at module init by init_zilstats_type() in pyzfs_kstat.c.
+ *
+ * File format (from module/zfs/zil.c in the ZFS source tree):
+ *   Line 1: metadata header -- skip
+ *   Line 2: column names "name  type  data" -- skip
+ *   Line 3+: "<name>  <type>  <value>"
+ *     All ZIL fields are KSTAT_DATA_UINT64 (type 4).
+ */
+PyObject *
+py_get_zilstats(PyObject *module, PyObject *args)
+{
+    pyzfs_kstat_state_t *state = NULL;
+    FILE *fp = NULL;
+    PyObject *result = NULL;
+    PyObject *val = NULL;
+    char line[256];
+    char name[64];
+    char valstr[24];
+    char *endptr = NULL;
+    int nscanned = 0;
+    int idx = 0;
+
+    PySys_Audit("truenas_pylibzfs.kstat.get_zilstats", NULL);
+
+    state = (pyzfs_kstat_state_t *)PyModule_GetState(module);
+
+    Py_BEGIN_ALLOW_THREADS
+    fp = fopen(ZILSTATS_PATH, "r");
+    Py_END_ALLOW_THREADS
+
+    if (fp == NULL) {
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, ZILSTATS_PATH);
+        return NULL;
+    }
+
+    /* Skip the two header lines. */
+    if (fgets(line, sizeof(line), fp) == NULL ||
+        fgets(line, sizeof(line), fp) == NULL) {
+        fclose(fp);
+        PyErr_SetString(PyExc_ValueError,
+            "Unexpected format in " ZILSTATS_PATH
+            ": missing header lines");
+        return NULL;
+    }
+
+    result = PyStructSequence_New(state->zilstats_type);
+    if (result == NULL) {
+        fclose(fp);
+        return NULL;
+    }
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        /*
+         * %*u discards the type column (always KSTAT_DATA_UINT64 = 4
+         * for ZIL stats). PyLong_FromString handles the conversion.
+         */
+        nscanned = sscanf(line, "%63s %*u %23s", name, valstr);
+        if (nscanned != 2)
+            continue;
+
+        if (idx >= ZILSTATS_N_FIELDS) {
+            fclose(fp);
+            PyErr_Format(PyExc_ValueError,
+                ZILSTATS_PATH " has more than %d data fields. "
+                "Update zilstats.c and stubs to match the installed "
+                "ZFS version.",
+                ZILSTATS_N_FIELDS);
+            Py_DECREF(result);
+            return NULL;
+        }
+
+        val = PyLong_FromString(valstr, &endptr, 10);
+        if (val == NULL) {
+            fclose(fp);
+            Py_DECREF(result);
+            return NULL;
+        }
+        if (*endptr != '\0') {
+            fclose(fp);
+            Py_DECREF(val);
+            PyErr_Format(PyExc_ValueError,
+                ZILSTATS_PATH " field %d (%s): "
+                "trailing garbage in value \"%s\"",
+                idx, name, valstr);
+            Py_DECREF(result);
+            return NULL;
+        }
+
+        PyStructSequence_SetItem(result, idx, val); /* steals ref */
+        idx++;
+    }
+
+    fclose(fp);
+
+    if (idx != ZILSTATS_N_FIELDS) {
+        PyErr_Format(PyExc_ValueError,
+            ZILSTATS_PATH " has %d data fields; expected %d. "
+            "Update zilstats.c and stubs to match the installed "
+            "ZFS version.",
+            idx, ZILSTATS_N_FIELDS);
+        Py_DECREF(result);
+        return NULL;
+    }
+
+    return result;
+}

--- a/stubs/kstat.pyi
+++ b/stubs/kstat.pyi
@@ -444,6 +444,88 @@ class ArcStats:
     def __replace__(self, **changes: Any) -> Self: ...
 
 
+@final
+class ZilStats:
+    """Snapshot of ZFS ZIL (ZFS Intent Log) statistics
+    read from /proc/spl/kstat/zfs/zil.
+    """
+
+    # Commit counters
+    zil_commit_count: int
+    """Number of times a ZIL commit (e.g. fsync) has been requested."""
+    zil_commit_writer_count: int
+    """Number of times the ZIL has been flushed to stable storage. This is
+    less than zil_commit_count when commits are merged."""
+    zil_commit_error_count: int
+    """ZIL commits that failed due to an I/O error during write or flush,
+    forcing a fallback to txg_wait_synced()."""
+    zil_commit_stall_count: int
+    """ZIL commits that stalled because LWB (Log Write Block) allocation
+    failed and the ZIL chain was abandoned, forcing a fallback to
+    txg_wait_synced()."""
+    zil_commit_suspend_count: int
+    """ZIL commits that failed because the ZIL was suspended, forcing a
+    fallback to txg_wait_synced()."""
+    zil_commit_crash_count: int
+    """ZIL commits that failed because the ZIL crashed, forcing a fallback
+    to txg_wait_synced()."""
+
+    # Intent transaction (itx) counters
+    zil_itx_count: int
+    """Total number of intent transactions (reads, writes, renames, etc.)
+    committed to the ZIL."""
+    zil_itx_indirect_count: int
+    """Transactions written using indirect mode (WR_INDIRECT): data is written
+    directly to the pool via dmu_sync() and a block pointer is stored in the
+    log record instead of the data itself."""
+    zil_itx_indirect_bytes: int
+    """Bytes of transaction data written using indirect mode. Accumulates the
+    logical data length, not the log record size."""
+    zil_itx_copied_count: int
+    """Transactions written using immediate-copy mode (WR_COPIED): data is
+    copied directly into the log record at commit time because the transaction
+    was synchronous (O_SYNC or O_DSYNC)."""
+    zil_itx_copied_bytes: int
+    """Bytes of transaction data written using immediate-copy mode."""
+    zil_itx_needcopy_count: int
+    """Transactions written using deferred-copy mode (WR_NEED_COPY): data is
+    retrieved from the DMU and copied into the log record only if the write
+    needs to be flushed."""
+    zil_itx_needcopy_bytes: int
+    """Bytes of transaction data written using deferred-copy mode."""
+
+    # Normal pool metaslab
+    zil_itx_metaslab_normal_count: int
+    """Transactions allocated to the normal (non-slog) storage pool."""
+    zil_itx_metaslab_normal_bytes: int
+    """Log record bytes allocated to the normal pool. Accumulates actual
+    log record sizes, which exclude data for indirect writes.
+    Invariant: bytes <= write <= alloc."""
+    zil_itx_metaslab_normal_write: int
+    """Bytes written to the normal pool for ZIL log blocks."""
+    zil_itx_metaslab_normal_alloc: int
+    """Bytes allocated from the normal pool for ZIL log blocks."""
+
+    # Slog (Separate Intent Log) metaslab
+    zil_itx_metaslab_slog_count: int
+    """Transactions allocated to the slog (Separate Intent Log) device.
+    If no dedicated log device is configured, slog statistics remain zero
+    and all activity is counted under the normal pool."""
+    zil_itx_metaslab_slog_bytes: int
+    """Log record bytes allocated to the slog device.
+    Invariant: bytes <= write <= alloc."""
+    zil_itx_metaslab_slog_write: int
+    """Bytes written to the slog device for ZIL log blocks."""
+    zil_itx_metaslab_slog_alloc: int
+    """Bytes allocated from the slog device for ZIL log blocks."""
+
+    __match_args__: ClassVar[tuple[str, ...]]
+    n_fields: ClassVar[int]           # = 21
+    n_sequence_fields: ClassVar[int]  # = 21
+    n_unnamed_fields: ClassVar[int]   # = 0
+    def __replace__(self, **changes: Any) -> Self: ...
+
+
 def get_arcstats() -> ArcStats:
     """Read and return a snapshot of ZFS ARC statistics.
 
@@ -456,6 +538,23 @@ def get_arcstats() -> ArcStats:
         /proc/spl/kstat/zfs/arcstats could not be opened.
     ValueError
         /proc/spl/kstat/zfs/arcstats has an unexpected format or field
+        count, indicating a ZFS version mismatch.
+    """
+    ...
+
+
+def get_zilstats() -> ZilStats:
+    """Read and return a snapshot of ZFS ZIL (ZFS Intent Log) statistics.
+
+    Each call opens and reads /proc/spl/kstat/zfs/zil, so successive
+    calls return independent snapshots reflecting the current kernel state.
+
+    Raises
+    ------
+    OSError
+        /proc/spl/kstat/zfs/zil could not be opened.
+    ValueError
+        /proc/spl/kstat/zfs/zil has an unexpected format or field
         count, indicating a ZFS version mismatch.
     """
     ...

--- a/tests/test_kstat_zilstats.py
+++ b/tests/test_kstat_zilstats.py
@@ -1,0 +1,90 @@
+"""
+Verify that the hard-coded ZilStats field list stays in sync with
+/proc/spl/kstat/zfs/zil.
+
+This test must run on a host with the ZFS kernel module loaded and must be
+built against the same ZFS source tree used to compile truenas_pylibzfs.
+It is intended to run in the CI environment (GitHub Actions) where the build
+VM has the target ZFS version installed.
+
+If this test fails, the installed ZFS version has added, removed, or
+reordered ZIL stats fields relative to the hard-coded list in
+src/pyzfs_kstat/zilstats.c and stubs/. Update both files to match.
+"""
+
+import sys
+
+from truenas_pylibzfs import kstat
+
+ZILSTATS_PATH = "/proc/spl/kstat/zfs/zil"
+
+
+def _read_proc_fields():
+    """Return the ordered list of field names from ZILSTATS_PATH."""
+    with open(ZILSTATS_PATH) as f:
+        lines = f.readlines()
+    # Line 0: metadata header; line 1: column header; lines 2+: data.
+    return [line.split()[0] for line in lines[2:] if line.strip()]
+
+
+def _zilstats_fields():
+    """
+    Return the ordered field names of the ZilStats struct sequence type.
+
+    PyStructSequence types gained an automatic _fields tuple in Python 3.13.
+    For earlier versions, extract field names from the member descriptors that
+    PyStructSequence_NewType adds to the type dict.
+    """
+    t = type(kstat.get_zilstats())
+    if hasattr(t, '_fields'):
+        return list(t._fields)
+    # Identify the member_descriptor C type via a known PyStructSequence
+    # (sys.version_info), then collect all such descriptors from our type.
+    _mdt = type(type(sys.version_info).__dict__['major'])
+    return [k for k, v in t.__dict__.items() if isinstance(v, _mdt)]
+
+
+def test_zilstats_fields_in_sync():
+    """
+    Field names and order in ZilStats must exactly match ZILSTATS_PATH.
+
+    Checks both the set of names (catches additions and removals) and the
+    order (catches reorderings that would silently mis-assign values).
+    """
+    proc_fields = _read_proc_fields()
+    ext_fields = _zilstats_fields()
+
+    assert ext_fields == proc_fields, (
+        "ZilStats field list is out of sync with {}.\n"
+        "  Only in {}: {}\n"
+        "  Only in extension: {}\n"
+        "  Update src/pyzfs_kstat/zilstats.c (ZILSTATS_N_FIELDS and "
+        "zilstats_fields[]) and stubs/ to match.".format(
+            ZILSTATS_PATH,
+            ZILSTATS_PATH,
+            sorted(set(proc_fields) - set(ext_fields)),
+            sorted(set(ext_fields) - set(proc_fields)),
+        )
+    )
+
+
+def test_zilstats_returns_ints():
+    """All ZilStats field values must be integers."""
+    stats = kstat.get_zilstats()
+    for i, value in enumerate(stats):
+        assert isinstance(value, int), (
+            "ZilStats field {} expected int, got {}".format(i, type(value).__name__)
+        )
+
+
+def test_zilstats_field_count():
+    """ZilStats field count must equal ZILSTATS_N_FIELDS (21)."""
+    stats = kstat.get_zilstats()
+    assert len(stats) == 21
+
+
+def test_zilstats_successive_calls_are_independent():
+    """Two successive get_zilstats() calls must return distinct objects."""
+    a = kstat.get_zilstats()
+    b = kstat.get_zilstats()
+    assert a is not b


### PR DESCRIPTION
This commit expands the kstat submodule in truenas_pylibzfs so that it includes a `get_zilstats` method that can be used to retrieve a struct sequence object containing the contents of /proc/spl/kstat/zfs/zil. The advantage of doing it this way is that we have consistent documentation, typing stubs, and the truenas_pylibzfs module build workflows will fail if the it gets out of sync with the counters that the openzfs kmod provides.