### PR TITLE
NAS-140641 / 26.0.0-BETA.2 / truenas_pylibzfs: Add contributing section to README.md (by anodos325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This library is not designed to be backwards compatible with OpenZFS versions no
 - `libbsd-dev`
 - `libssl-dev`
 
+## Contributing
+
+Pull requests that do not include tests exercising new functionality or validating bug fixes will not be accepted. Where it is not practical to add tests, explain why in the PR description.
+
 ## Build
 
 Build a Debian package:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ This library is not designed to be backwards compatible with OpenZFS versions no
 
 Pull requests that do not include tests exercising new functionality or validating bug fixes will not be accepted. Where it is not practical to add tests, explain why in the PR description.
 
+Any new functionality (methods, objects, parameters) must be documented following the existing standards in the repository. Type stubs in `stubs/` must be kept in sync with the codebase and documentation.
+
 ## Build
 
 Build a Debian package:


### PR DESCRIPTION
This commit adds a clarifying comment to the README.md for our truenas_pylibzfs repository that we will generally not accept PRs that do not include tests for the fixes or new functionality. Among other things this guideline may help us get better AI-generated code from community members since it will be included in context for tooling being used.

Original PR: https://github.com/truenas/truenas_pylibzfs/pull/238
