### PR TITLE
NAS-140920 / 27.0.0-BETA.1 / truenas_pylibzfs: Fix UB and potential segfault in import_pool

### DIFF
--- a/src/libzfs/py_zfs.c
+++ b/src/libzfs/py_zfs.c
@@ -1462,14 +1462,15 @@ PyObject *py_zfs_import_pool(PyObject *self,
 	}
 
 	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".import_pool",
-			"OOpOpOO",
+			"OOOOOOOO",
 			py_name ? py_name : Py_None,
 			py_guid ? py_guid : Py_None,
-			allow_missing_log,
+			allow_missing_log ? Py_True : Py_False,
 			py_altroot ? py_altroot : Py_None,
-			force,
+			force ? Py_True : Py_False,
 			pyprops ? pyprops : Py_None,
-			py_tmpname ? py_tmpname : Py_None) < 0) {
+			py_tmpname ? py_tmpname : Py_None,
+			py_device ? py_device : Py_None) < 0) {
 		return NULL;
 	}
 


### PR DESCRIPTION
Discovered during github workflow functional testing of new PR. The Sys_Audit format string in the import_pool method contains an unsupported character. There are a variety of C API format strings in cpython and p is OK for parsing arguments tuples, but not for passing into audit callback hooks.

This commit converts to python bool and passes that instead using the standard O (object) argument.