### PR TITLE
NAS-140970 / 26.0.0-BETA.2 / truenas_pylibzfs: survive ZFS kernel/userland version mismatch (by anodos325)

### DIFF
--- a/src/libzfs/README.md
+++ b/src/libzfs/README.md
@@ -138,3 +138,19 @@ All extension types set `.tp_new = py_no_new_impl`, blocking direct Python
 construction. Internal C factory functions allocate via `Type.tp_alloc(&Type, 0)`
 directly. When adding a new type, follow the same pattern - no `py_xxx_new` or
 `py_xxx_init` boilerplate.
+
+### ZFS version skew (ZFS kernel module / userland mismatch)
+
+`PyInit_truenas_pylibzfs` calls `zfs_version_userland()` and
+`zfs_version_kernel()` and raises `ImportError` if they disagree. Set
+`_PYLIBZFS_ALLOW_VERSION_MISMATCH=1` in the environment to bypass the check
+for read-only callers that accept reduced functionality.
+
+`init_py_struct_prop_state` (`py_zfs_prop.c`) and
+`init_py_struct_zpool_prop_state` (`py_zfs_pool_prop.c`) tolerate runtime
+property invisibility. Properties marked `pd_zfs_mod_supported = false` by
+the running ZFS kernel module, and properties whose `pd_name` is NULL
+because the linked libzfs does not register the enum value, are exposed as
+StructSequence slots that always return `None`. Field names are synthesized
+when libzfs has no name to offer, keeping the structseq shape stable across
+ZFS kernel module versions.

--- a/src/libzfs/README.md
+++ b/src/libzfs/README.md
@@ -144,7 +144,10 @@ directly. When adding a new type, follow the same pattern - no `py_xxx_new` or
 `PyInit_truenas_pylibzfs` calls `zfs_version_userland()` and
 `zfs_version_kernel()` and raises `ImportError` if they disagree. Set
 `_PYLIBZFS_ALLOW_VERSION_MISMATCH=1` in the environment to bypass the check
-for read-only callers that accept reduced functionality.
+for read-only callers that accept reduced functionality; on bypass a
+`RuntimeWarning` is emitted naming both versions. The override is matched
+strictly against the literal value `"1"`; any other value (including empty)
+is treated as unset.
 
 `init_py_struct_prop_state` (`py_zfs_prop.c`) and
 `init_py_struct_zpool_prop_state` (`py_zfs_pool_prop.c`) tolerate runtime

--- a/src/libzfs/py_zfs_pool_prop.c
+++ b/src/libzfs/py_zfs_pool_prop.c
@@ -70,17 +70,33 @@ void init_py_struct_zpool_prop_state(pylibzfs_state_t *state)
 {
 	size_t i;
 	PyTypeObject *obj;
+	char fallback_name[64];
 
 	for (i = 0; i < ZPOOL_NUM_PROPS; i++) {
 		zpool_prop_t prop = (zpool_prop_t)i;
 		const char *name = zpool_prop_to_name(prop);
-		char *doc = py_create_zpool_prop_doc(name, prop);
-		char *heap_name = pymem_strdup(name);
+		char *doc = NULL;
+		char *heap_name = NULL;
 
 		/*
-		 * If either allocation failed, bail out hard — we can't
-		 * operate correctly without these fields.
+		 * zpool_prop_to_name returns NULL when the linked libzfs
+		 * is older than the headers we compiled against and never
+		 * registered the enum value. Synthesize a placeholder
+		 * name so PyStructSequence_NewType has a non-NULL field
+		 * name to work with.
 		 */
+		if (name == NULL || *name == '\0') {
+			snprintf(fallback_name, sizeof(fallback_name),
+				 "unsupported_zpool_prop_%d", (int)prop);
+			name = fallback_name;
+			doc = pymem_strdup("Pool property not supported by "
+					   "the linked libzfs.");
+		} else {
+			doc = py_create_zpool_prop_doc(name, prop);
+		}
+
+		heap_name = pymem_strdup(name);
+
 		PYZFS_ASSERT(heap_name, "Malloc failure in pool prop fields.");
 		PYZFS_ASSERT(doc, "Malloc failure in pool prop fields.");
 

--- a/src/libzfs/py_zfs_prop.c
+++ b/src/libzfs/py_zfs_prop.c
@@ -132,23 +132,54 @@ void init_py_struct_prop_state(pylibzfs_state_t *state)
 {
 	size_t i;
 	PyTypeObject *obj;
+	char fallback_name[64];
+	char unsupported_doc[128];
 
 	for (i = 0; i < ARRAY_SIZE(zfs_prop_table); i++) {
-		const char *name = zfs_prop_to_name(zfs_prop_table[i].prop);
-		const char *doc = NULL;
 		zfs_prop_t prop = zfs_prop_table[i].prop;
+		const char *name = zfs_prop_to_name(prop);
+		const char *doc = NULL;
+		boolean_t supported;
 
 		/*
-		 * zfs_prop_table must only contain visible properties.
-		 * Hidden properties (zprop_register_hidden) are commented
-		 * out in the table.  CPython 3.13 structseq_repr() and
-		 * __replace__() do not support PyStructSequence_UnnamedField
-		 * in the visible sequence range.
+		 * A property in zfs_prop_table can be runtime invisible
+		 * for two reasons:
+		 *
+		 *   1. The loaded ZFS kernel module does not advertise it
+		 *      via sysfs, so libzfs marks pd_zfs_mod_supported
+		 *      false and zfs_prop_visible() returns false.
+		 *   2. The linked libzfs is older than the headers we
+		 *      compiled against and never registered the enum
+		 *      value, so zfs_prop_to_name() returns NULL.
+		 *
+		 * Degrade gracefully in both cases: synthesize a field
+		 * name (structseq_repr in CPython rejects NULL names)
+		 * and leave the runtime slot returning None, which
+		 * setup_zfs_prop_type already does whenever enum_obj is
+		 * NULL.
 		 */
-		PYZFS_ASSERT(zfs_prop_visible(prop),
-			     "Hidden property in zfs_prop_table.");
+		if (name == NULL) {
+			snprintf(fallback_name, sizeof(fallback_name),
+				 "unsupported_zfs_prop_%d", (int)prop);
+			name = fallback_name;
+			supported = B_FALSE;
+			snprintf(unsupported_doc, sizeof(unsupported_doc),
+				 "%s: property is not registered by the "
+				 "loaded libzfs.", name);
+		} else if (!zfs_prop_visible(prop)) {
+			supported = B_FALSE;
+			snprintf(unsupported_doc, sizeof(unsupported_doc),
+				 "%s: property is not supported by the "
+				 "running ZFS kernel module.", name);
+		} else {
+			supported = B_TRUE;
+		}
 
-		doc = py_create_prop_doc(name, prop);
+		if (supported) {
+			doc = py_create_prop_doc(name, prop);
+		} else {
+			doc = pymem_strdup(unsupported_doc);
+		}
 
 		state->struct_prop_fields[i].name = pymem_strdup(name);
 		PYZFS_ASSERT(state->struct_prop_fields[i].name,

--- a/src/libzfs/py_zfs_prop.c
+++ b/src/libzfs/py_zfs_prop.c
@@ -158,7 +158,7 @@ void init_py_struct_prop_state(pylibzfs_state_t *state)
 		 * setup_zfs_prop_type already does whenever enum_obj is
 		 * NULL.
 		 */
-		if (name == NULL) {
+		if (name == NULL || *name == '\0') {
 			snprintf(fallback_name, sizeof(fallback_name),
 				 "unsupported_zfs_prop_%d", (int)prop);
 			name = fallback_name;

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -547,25 +547,42 @@ int py_init_libzfs(void)
 	libzfs_handle_t *tmplz = NULL;
 	const char *userland = NULL;
 	char *kernel = NULL;
+	const char *override = NULL;
 	boolean_t versions_ok;
 
 	/*
 	 * Reject loading when the libzfs userland and the running ZFS
 	 * kernel module versions disagree. _PYLIBZFS_ALLOW_VERSION_MISMATCH=1
 	 * overrides the check for read-mostly callers that accept reduced
-	 * functionality (unsupported properties expose as None).
+	 * functionality (unsupported properties expose as None); in that case
+	 * we still emit a RuntimeWarning so the mismatch is visible.
 	 */
 	versions_ok = py_zfs_versions_match(&userland, &kernel);
-	if (!versions_ok && getenv("_PYLIBZFS_ALLOW_VERSION_MISMATCH") == NULL) {
-		PyErr_Format(PyExc_ImportError,
-			     "zfs userland %s does not match kernel %s; "
-			     "set _PYLIBZFS_ALLOW_VERSION_MISMATCH=1 to "
-			     "load anyway (unsupported properties will be "
-			     "exposed as None).",
-			     userland ? userland : "<unknown>",
-			     kernel ? kernel : "<unknown>");
-		free(kernel);
-		return B_FALSE;
+	if (!versions_ok) {
+		override = getenv("_PYLIBZFS_ALLOW_VERSION_MISMATCH");
+		if (override == NULL || strcmp(override, "1") != 0) {
+			PyErr_Format(PyExc_ImportError,
+				     "zfs userland %s does not match kernel "
+				     "%s; set _PYLIBZFS_ALLOW_VERSION_MISMATCH"
+				     "=1 to load anyway (unsupported "
+				     "properties will be exposed as None).",
+				     userland ? userland : "<unknown>",
+				     kernel ? kernel : "<unknown>");
+			free(kernel);
+			return B_FALSE;
+		}
+
+		if (PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
+				     "zfs userland %s does not match kernel "
+				     "%s; continuing because "
+				     "_PYLIBZFS_ALLOW_VERSION_MISMATCH=1 "
+				     "(unsupported properties will be exposed "
+				     "as None).",
+				     userland ? userland : "<unknown>",
+				     kernel ? kernel : "<unknown>") < 0) {
+			free(kernel);
+			return B_FALSE;
+		}
 	}
 	free(kernel);
 

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -506,11 +506,14 @@ static struct PyModuleDef truenas_pylibzfs_constants = {
  * read from the ZFS kernel module (caller must free with free()), or
  * NULL if it could not be read.
  */
+#define ZFS_USERLAND_VERSION_PREFIX "zfs-"
+
 static
 boolean_t py_zfs_versions_match(const char **uver_out, char **kver_out)
 {
 	const char *userland = zfs_version_userland();
 	char *kernel = zfs_version_kernel();
+	const size_t prefix_len = strlen(ZFS_USERLAND_VERSION_PREFIX);
 
 	*uver_out = userland;
 	*kver_out = kernel;
@@ -527,12 +530,14 @@ boolean_t py_zfs_versions_match(const char **uver_out, char **kver_out)
 
 	/*
 	 * zfs_version_userland() returns ZFS_META_ALIAS, of the form
-	 * "zfs-<version>[-<release>]". zfs_version_kernel() reads
-	 * /sys/module/zfs/version, which carries the same shape. An
-	 * exact string match is the strongest signal that the property
-	 * table libzfs has just initialized matches what the running
-	 * ZFS kernel module advertises.
+	 * "zfs-<version>". zfs_version_kernel() returns the contents
+	 * of /sys/module/zfs/version, which is just "<version>". Strip
+	 * the "zfs-" prefix from the userland string before comparing.
 	 */
+	if (strncmp(userland, ZFS_USERLAND_VERSION_PREFIX, prefix_len) == 0)
+		return (strcmp(userland + prefix_len, kernel) == 0)
+		    ? B_TRUE : B_FALSE;
+
 	return (strcmp(userland, kernel) == 0) ? B_TRUE : B_FALSE;
 }
 

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -498,10 +498,71 @@ static struct PyModuleDef truenas_pylibzfs_constants = {
 };
 
 
+/*
+ * Compare the libzfs userland version string against the running ZFS
+ * kernel module version string. Returns B_TRUE if they match or if the
+ * ZFS kernel module side does not expose a version (e.g. module not
+ * loaded), B_FALSE if they differ. Sets *kver_out to the version string
+ * read from the ZFS kernel module (caller must free with free()), or
+ * NULL if it could not be read.
+ */
+static
+boolean_t py_zfs_versions_match(const char **uver_out, char **kver_out)
+{
+	const char *userland = zfs_version_userland();
+	char *kernel = zfs_version_kernel();
+
+	*uver_out = userland;
+	*kver_out = kernel;
+
+	if (kernel == NULL) {
+		/*
+		 * ZFS kernel module version unreadable (sysfs missing or
+		 * module not loaded). libzfs_init() below will surface the
+		 * real problem with a meaningful errno; do not treat this
+		 * as a mismatch.
+		 */
+		return B_TRUE;
+	}
+
+	/*
+	 * zfs_version_userland() returns ZFS_META_ALIAS, of the form
+	 * "zfs-<version>[-<release>]". zfs_version_kernel() reads
+	 * /sys/module/zfs/version, which carries the same shape. An
+	 * exact string match is the strongest signal that the property
+	 * table libzfs has just initialized matches what the running
+	 * ZFS kernel module advertises.
+	 */
+	return (strcmp(userland, kernel) == 0) ? B_TRUE : B_FALSE;
+}
+
 static
 int py_init_libzfs(void)
 {
 	libzfs_handle_t *tmplz = NULL;
+	const char *userland = NULL;
+	char *kernel = NULL;
+	boolean_t versions_ok;
+
+	/*
+	 * Reject loading when the libzfs userland and the running ZFS
+	 * kernel module versions disagree. _PYLIBZFS_ALLOW_VERSION_MISMATCH=1
+	 * overrides the check for read-mostly callers that accept reduced
+	 * functionality (unsupported properties expose as None).
+	 */
+	versions_ok = py_zfs_versions_match(&userland, &kernel);
+	if (!versions_ok && getenv("_PYLIBZFS_ALLOW_VERSION_MISMATCH") == NULL) {
+		PyErr_Format(PyExc_ImportError,
+			     "zfs userland %s does not match kernel %s; "
+			     "set _PYLIBZFS_ALLOW_VERSION_MISMATCH=1 to "
+			     "load anyway (unsupported properties will be "
+			     "exposed as None).",
+			     userland ? userland : "<unknown>",
+			     kernel ? kernel : "<unknown>");
+		free(kernel);
+		return B_FALSE;
+	}
+	free(kernel);
 
 	// We need to initialize libzfs handle temporarily so that
 	// zfs and zpool properties get properly initialized so that


### PR DESCRIPTION
A truenas-grub.py invocation inside an update chroot (newer libzfs over an older host kernel) aborted with Py_FatalError / SIGABRT from init_py_struct_prop_state because libzfs marked new dataset properties pd_zfs_mod_supported=false via sysfs and zfs_prop_visible() returned false. Replace the fatal assertion with graceful degradation: unsupported slots are exposed as None (the runtime accessors already handled this), and the StructSequence field name is synthesized when libzfs has none to offer. Apply the symmetric hardening to init_py_struct_zpool_prop_state.

Add an explicit version probe in py_init_libzfs that compares zfs_version_userland() and zfs_version_kernel() and raises a catchable ImportError naming both versions on mismatch, with environment variable _PYLIBZFS_ALLOW_VERSION_MISMATCH=1 as an escape hatch for read-mostly callers.

Original PR: https://github.com/truenas/truenas_pylibzfs/pull/250
