### PR TITLE
NAS-140999 / 26.0.0-RC.1 / add l2_ndev arcstats field (by ixhamza)

### DIFF
--- a/src/pyzfs_kstat/pyzfs_kstat.c
+++ b/src/pyzfs_kstat/pyzfs_kstat.c
@@ -345,6 +345,9 @@ PyDoc_STRVAR(arcstat_uncached_evictable_metadata__doc__,
 
 /* L2ARC (Level 2 ARC cache device) */
 
+PyDoc_STRVAR(arcstat_l2_ndev__doc__,
+"Number of L2ARC cache devices currently attached (l2arc_ndev).");
+
 PyDoc_STRVAR(arcstat_l2_hits__doc__,
 "L2ARC (Level 2 ARC cache device) read hits.");
 
@@ -686,6 +689,7 @@ static PyStructSequence_Field arcstats_fields[] = {
     {"uncached_metadata", arcstat_uncached_metadata__doc__},
     {"uncached_evictable_data", arcstat_uncached_evictable_data__doc__},
     {"uncached_evictable_metadata", arcstat_uncached_evictable_metadata__doc__},
+    {"l2_ndev", arcstat_l2_ndev__doc__},
     {"l2_hits", arcstat_l2_hits__doc__},
     {"l2_misses", arcstat_l2_misses__doc__},
     {"l2_prefetch_asize", arcstat_l2_prefetch_asize__doc__},

--- a/src/pyzfs_kstat/pyzfs_kstat.h
+++ b/src/pyzfs_kstat/pyzfs_kstat.h
@@ -20,7 +20,7 @@
  * This constant must stay in sync with ARCSTATS_PATH. The test
  * tests/test_kstat_arcstats.py enforces that invariant in CI.
  */
-#define ARCSTATS_N_FIELDS 147
+#define ARCSTATS_N_FIELDS 148
 
 /*
  * Path to the ZIL (ZFS Intent Log) kstat file exposed by the ZFS

--- a/stubs/kstat.pyi
+++ b/stubs/kstat.pyi
@@ -247,6 +247,8 @@ class ArcStats:
     ARC_FLAG_UNCACHED (no outstanding holds on the buffer)."""
 
     # L2ARC (Level 2 ARC cache device)
+    l2_ndev: int
+    """Number of L2ARC cache devices currently attached (l2arc_ndev)."""
     l2_hits: int
     """L2ARC (Level 2 ARC cache device) read hits."""
     l2_misses: int


### PR DESCRIPTION
ZFS now exposes `l2_ndev` in `/proc/spl/kstat/zfs/arcstats`, raising the Linux field count from 147 to 148. Bump `ARCSTATS_N_FIELDS` and expose `l2_ndev` in `arcstats_fields[]` and the `kstat.pyi` stub.

ZFS PR: https://github.com/truenas/zfs/pull/383

### Testing
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/custom_build/job/build/144/)
- [API Tests](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/8903/)

Original PR: https://github.com/truenas/truenas_pylibzfs/pull/253
