### PR TITLE
NAS-141403 / 27.0.0-BETA.1 / Unmount whole descendant tree on recursive unmount

### DIFF
--- a/src/libzfs/py_zfs_resource.c
+++ b/src/libzfs/py_zfs_resource.c
@@ -1068,7 +1068,10 @@ PyDoc_STRVAR(py_zfs_resource_unmount__doc__,
 "follow_symlinks: bool, optional, default=False\n"
 "    Don't dereference mountpoint if it is a symbolic link.\n"
 "recursive: bool, optional, default=False\n"
-"    Unmount any children inheriting the mountpoint property.\n\n"
+"    Unmount the entire descendant filesystem tree, children before\n"
+"    parents, regardless of whether descendants inherit the mountpoint\n"
+"    property. When unload_encryption_key is set, encryption keys are\n"
+"    unloaded only after the whole subtree has been unmounted.\n\n"
 ""
 "Returns\n"
 "-------\n"
@@ -1136,6 +1139,37 @@ PyObject *py_zfs_resource_open_pool(PyObject *self, PyObject *args_unused)
 	return out;
 }
 
+/*
+ * zfs_iter_filesystems_v2 callback that unmounts a dataset subtree in
+ * dataset-hierarchy post-order (descendants before their parent).
+ *
+ * zfs_unmountall() unmounts in mountpoint order rather than dataset order, so a
+ * child with its own LOCAL mountpoint mounted outside the parent's tree can be
+ * left mounted -- and, when MS_CRYPT is set, the encryption-root key unload then
+ * fails with EBUSY because that child still holds the key. Walking the dataset
+ * tree post-order guarantees every descendant is unmounted before its parent,
+ * so the key unload at an encryption root always runs with the subtree gone.
+ *
+ * The MS_CRYPT flag is carried per node exactly as zfs_unmountall() does; it
+ * only triggers a key unload at encryption roots.
+ */
+static int
+py_zfs_recursive_unmount_cb(zfs_handle_t *zhp, void *data)
+{
+	int *flags = (int *)data;
+	int ret = 0;
+
+	if (zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM) {
+		ret = zfs_iter_filesystems_v2(zhp, 0,
+		    py_zfs_recursive_unmount_cb, data);
+		if (ret == 0 && zfs_unmount(zhp, NULL, *flags) != 0)
+			ret = -1;
+	}
+
+	zfs_close(zhp);
+	return ret;
+}
+
 static
 PyObject *py_zfs_resource_unmount(PyObject *self,
 				  PyObject *args_unused,
@@ -1188,7 +1222,17 @@ PyObject *py_zfs_resource_unmount(PyObject *self,
 	Py_BEGIN_ALLOW_THREADS
 	PY_ZFS_LOCK(res->obj.pylibzfsp);
 	if (recurse) {
-		err = zfs_unmountall(res->obj.zhp, flags);
+		err = zfs_iter_filesystems_v2(res->obj.zhp, 0,
+		    py_zfs_recursive_unmount_cb, &flags);
+		/*
+		 * Unmount the target itself last, after its whole subtree, so
+		 * any encryption-key unload (MS_CRYPT) runs with no descendant
+		 * still holding the key. The target handle is owned by this
+		 * object, so unlike the descendants it is not closed here.
+		 */
+		if (err == 0 &&
+		    zfs_get_type(res->obj.zhp) == ZFS_TYPE_FILESYSTEM)
+			err = zfs_unmount(res->obj.zhp, NULL, flags);
 	} else {
 		err = zfs_unmount(res->obj.zhp, mp, flags);
 	}

--- a/tests/test_mountpoint.py
+++ b/tests/test_mountpoint.py
@@ -4,12 +4,38 @@ Tests for ZFSResource.get_mountpoint():
   - Dataset with legacy mountpoint returns None
   - Unmounted dataset returns None
   - Remount after unmount returns non-None
+
+Tests for recursive ZFSResource.unmount():
+  - A cross-tree island (descendant with its own LOCAL mountpoint mounted
+    outside the parent's tree, plus its children) is fully unmounted
+  - The encrypted variant additionally unloads the encryption key
 """
+
+import os
+import shutil
+import tempfile
 
 import pytest
 import truenas_pylibzfs
 
 POOL_NAME = 'testpool_mntpt'
+PASSPHRASE = 'Cats1234'
+
+
+def _mounted(lz, name):
+    """Return True if `name` is currently mounted, read from a fresh handle.
+
+    The recursive unmount operates on descendant handles internally, so a
+    handle opened before the call would report stale mount state; re-opening
+    reads the live ZFS_PROP_MOUNTED value.
+    """
+    rsrc = lz.open_resource(name=name)
+    d = rsrc.asdict(properties={truenas_pylibzfs.ZFSProperty.MOUNTED})
+    return d['properties']['mounted']['raw'] == 'yes'
+
+
+def _key_loaded(lz, name):
+    return lz.open_resource(name=name).crypto().info().key_is_loaded
 
 
 @pytest.fixture
@@ -86,3 +112,92 @@ def test_remount_after_unmount(pool):
             lz.destroy_resource(name=ds_name)
         except Exception:
             pass
+
+
+def test_recursive_unmount_clears_cross_tree_island(make_pool):
+    """Recursive unmount must clear a descendant whose LOCAL mountpoint lives
+    outside the parent's tree, along with that descendant's own children."""
+    pool_name = 'testpool_island'
+    lz, _, root = make_pool(pool_name)
+    base = tempfile.mkdtemp(prefix='pylibzfs_island_')
+    island = f'{pool_name}/island'
+    child = f'{pool_name}/island/child'
+    try:
+        lz.create_resource(
+            name=island,
+            type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM,
+            properties={
+                truenas_pylibzfs.ZFSProperty.MOUNTPOINT: os.path.join(base, 'island')
+            },
+        )
+        lz.create_resource(
+            name=child,
+            type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM,
+        )
+        lz.open_resource(name=island).mount()
+        lz.open_resource(name=child).mount()
+        assert _mounted(lz, island)
+        assert _mounted(lz, child)
+
+        root.unmount(force=True, recursive=True)
+
+        assert not _mounted(lz, island)
+        assert not _mounted(lz, child)
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def test_recursive_unmount_unloads_key_with_cross_tree_island(make_pool):
+    """An encrypted dataset hosting a cross-tree island must, on recursive
+    unmount with unload_encryption_key, unmount the whole subtree and unload
+    the key without the island leaving it busy.
+
+    The island mountpoint sorts lexically before the encryption root's so that
+    the (buggy) mountpoint-ordered unmount would unload the key before the
+    island is unmounted -- which is exactly the EBUSY case this guards."""
+    pool_name = 'testpool_enc_island'
+    lz, _, _ = make_pool(pool_name)
+    base = tempfile.mkdtemp(prefix='pylibzfs_enc_island_')
+    enc = f'{pool_name}/enc'
+    island = f'{pool_name}/enc/island'
+    child = f'{pool_name}/enc/island/child'
+    try:
+        crypto = lz.resource_cryptography_config(
+            keyformat='passphrase', key=PASSPHRASE
+        )
+        lz.create_resource(
+            name=enc,
+            type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM,
+            crypto=crypto,
+            properties={
+                truenas_pylibzfs.ZFSProperty.MOUNTPOINT: os.path.join(base, 'z_enc')
+            },
+        )
+        lz.create_resource(
+            name=island,
+            type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM,
+            properties={
+                truenas_pylibzfs.ZFSProperty.MOUNTPOINT: os.path.join(base, 'a_island')
+            },
+        )
+        lz.create_resource(
+            name=child,
+            type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM,
+        )
+        enc_rsrc = lz.open_resource(name=enc)
+        enc_rsrc.mount()
+        lz.open_resource(name=island).mount()
+        lz.open_resource(name=child).mount()
+        assert _mounted(lz, enc)
+        assert _mounted(lz, island)
+        assert _mounted(lz, child)
+        assert _key_loaded(lz, enc) is True
+
+        enc_rsrc.unmount(force=True, recursive=True, unload_encryption_key=True)
+
+        assert not _mounted(lz, enc)
+        assert not _mounted(lz, island)
+        assert not _mounted(lz, child)
+        assert _key_loaded(lz, enc) is False
+    finally:
+        shutil.rmtree(base, ignore_errors=True)


### PR DESCRIPTION
This commit fixes an issue where recursively unmounting an encrypted dataset could fail with EBUSY when a descendant had its own mountpoint outside the parent's tree. zfs_unmountall() unmounts in mountpoint order rather than dataset order, so such a descendant could still be mounted when the encryption root's key unload ran. We now walk the dataset hierarchy post-order, unmounting every descendant before its parent, so the key unload always runs with the subtree already gone.