### PR TITLE
NAS-141152 / 27.0.0-BETA.1 / `MoreRecentSnapshotsExist` exception

### DIFF
--- a/.github/workflows/scripts/qemu-4-test.sh
+++ b/.github/workflows/scripts/qemu-4-test.sh
@@ -152,7 +152,8 @@ import truenas_pylibzfs, sys
 for name in ('lzc', 'libzfs_types', 'property_sets', 'kstat'):
     sys.modules['truenas_pylibzfs.' + name] = getattr(truenas_pylibzfs, name)
 from mypy.stubtest import main
-sys.argv = ['stubtest', 'truenas_pylibzfs']
+sys.argv = ['stubtest', 'truenas_pylibzfs',
+            '--allowlist', 'tests/type_checks/stubtest_allowlist.txt']
 sys.exit(main())
 "
 STUBTEST_EXIT=$?

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -3,6 +3,9 @@
 static
 PyObject *PyExc_ZFSError;
 
+static
+PyObject *PyExc_MoreRecentSnapshots;
+
 PyDoc_STRVAR(py_zfs_exception__doc__,
 "ZFSException(exception)\n"
 "-----------------------\n\n"
@@ -55,6 +58,41 @@ PyObject *setup_zfs_exception(void)
 
 	Py_DECREF(dict);
 	return PyExc_ZFSError;
+}
+
+PyDoc_STRVAR(py_more_recent_snapshots_exc__doc__,
+"MoreRecentSnapshotsExist(snapshots)\n"
+"-----------------------------------\n\n"
+"Raised by lzc.rollback() when the target dataset cannot be rolled back to\n"
+"the requested snapshot because more recent snapshots or bookmarks exist.\n\n"
+"This is a subclass of ZFSException; its `code` is ZFSError.EZFS_EXISTS.\n\n"
+"attributes:\n"
+"-----------\n"
+"snapshots: list[str]\n"
+"    Names of the snapshots and bookmarks that are more recent than the\n"
+"    target snapshot and therefore block the rollback.\n"
+);
+PyObject *setup_more_recent_snapshots_exception(void)
+{
+	PyObject *dict = NULL;
+
+	dict = Py_BuildValue("{s:O}", "snapshots", Py_None);
+	if (dict == NULL)
+		return NULL;
+
+	PyExc_MoreRecentSnapshots = PyErr_NewExceptionWithDoc(
+		PYLIBZFS_MODULE_NAME ".MoreRecentSnapshotsExist",
+		py_more_recent_snapshots_exc__doc__,
+		PyExc_ZFSError,
+		dict);
+
+	Py_DECREF(dict);
+	return PyExc_MoreRecentSnapshots;
+}
+
+PyObject *get_more_recent_snapshots_exc_type(void)
+{
+	return PyExc_MoreRecentSnapshots;
 }
 
 const char *zfs_error_name(zfs_error_t error)

--- a/src/libzfs_core/README.md
+++ b/src/libzfs_core/README.md
@@ -34,7 +34,7 @@ The shared `local_replicate` implementation - pipe + worker threads, progress po
 | `destroy_snapshots` | `lzc_destroy_snaps` | yes |
 | `create_holds` | `lzc_hold` | yes |
 | `release_holds` | `lzc_release` | yes |
-| `rollback` | `lzc_rollback` | yes |
+| `rollback` | `lzc_rollback` / `lzc_rollback_to` | yes |
 | `run_channel_program` | `lzc_channel_program` | yes (unless readonly=True) |
 | `send` | `lzc_send` / `lzc_send_resume` | no (data transfer) |
 | `send_space` | `lzc_send_space` | no |
@@ -42,6 +42,13 @@ The shared `local_replicate` implementation - pipe + worker threads, progress po
 | `receive` | `lzc_receive` / `lzc_receive_resumable` | yes |
 | `local_replicate` | `lzc_send` + `lzc_receive` (paired in one call via an internal pipe and pthread) | yes |
 | `wait` | `lzc_wait` | no |
+
+## Exceptions
+
+| Python name | Base class | Raised by |
+|---|---|---|
+| `ZFSCoreException` | `RuntimeError` | most `lzc` methods (carries `code`, `msg`, `name`, `errors`) |
+| `truenas_pylibzfs.MoreRecentSnapshotsExist` | `ZFSException` | `rollback` when `snapshot_name` is not the most recent snapshot (`code` = `EZFS_EXISTS`); defined in the main package, not `lzc` |
 
 ## Developer notes
 

--- a/src/libzfs_core/py_zfs_core_module.c
+++ b/src/libzfs_core/py_zfs_core_module.c
@@ -1504,6 +1504,232 @@ static PyObject *py_lzc_program(PyObject *self,
 	return py_out;
 }
 
+typedef struct {
+	uint64_t txg;
+	boolean_t is_bookmark;
+	char name[ZFS_MAX_DATASET_NAME_LEN];
+} rollback_entry_t;
+
+typedef struct {
+	uint64_t target_txg;
+	boolean_t is_bookmark;	/* category of the current iteration pass */
+	rollback_entry_t *entries;
+	size_t count;
+	size_t capacity;
+	boolean_t alloc_error;
+} rollback_conflict_t;
+
+/*
+ * zfs_iter_f callback used to collect the snapshots and bookmarks that block a
+ * rollback. This runs with the GIL released (see raise_more_recent_snapshots),
+ * so it must touch only plain C state, never the Python C API.
+ *
+ * Every snapshot or bookmark whose creation TXG (Transaction Group) is newer
+ * than the rollback target is recorded in a growable C array, tagged with its
+ * TXG and category so the caller can order them afterwards. The iterator
+ * transfers ownership of each handle to the callback, so we zfs_close() it here.
+ */
+static int
+rollback_conflict_cb(zfs_handle_t *zhp, void *data)
+{
+	rollback_conflict_t *cb = data;
+	uint64_t txg;
+
+	txg = zfs_prop_get_int(zhp, ZFS_PROP_CREATETXG);
+	if (txg > cb->target_txg) {
+		rollback_entry_t *entry;
+
+		if (cb->count == cb->capacity) {
+			size_t newcap = cb->capacity ? cb->capacity * 2 : 16;
+			rollback_entry_t *tmp = realloc(cb->entries,
+			    newcap * sizeof(*tmp));
+			if (tmp == NULL) {
+				cb->alloc_error = B_TRUE;
+				zfs_close(zhp);
+				return (-1);
+			}
+			cb->entries = tmp;
+			cb->capacity = newcap;
+		}
+
+		entry = &cb->entries[cb->count++];
+		entry->txg = txg;
+		entry->is_bookmark = cb->is_bookmark;
+		strlcpy(entry->name, zfs_get_name(zhp), sizeof(entry->name));
+	}
+
+	zfs_close(zhp);
+	return (0);
+}
+
+/*
+ * qsort comparator: order conflicting entries the way the zfs(8) CLI reports
+ * them - snapshots before bookmarks, each group by ascending creation TXG
+ * (ties broken by name for determinism).
+ */
+static int
+rollback_entry_cmp(const void *a, const void *b)
+{
+	const rollback_entry_t *ea = a;
+	const rollback_entry_t *eb = b;
+
+	if (ea->is_bookmark != eb->is_bookmark)
+		return (ea->is_bookmark - eb->is_bookmark);
+	if (ea->txg < eb->txg)
+		return (-1);
+	if (ea->txg > eb->txg)
+		return (1);
+	return (strcmp(ea->name, eb->name));
+}
+
+/*
+ * Populate the ZFSException attributes on a MoreRecentSnapshotsExist instance:
+ * the standard `code`/`name` (EZFS_EXISTS) plus the `snapshots` list. Returns 0
+ * on success or -1 with a Python exception set.
+ */
+static int
+rollback_set_exc_attrs(PyObject *exc, PyObject *snapshots)
+{
+	PyObject *code = NULL;
+	PyObject *name = NULL;
+	int err;
+
+	code = PyLong_FromLong(EZFS_EXISTS);
+	if (code == NULL)
+		return (-1);
+	err = PyObject_SetAttrString(exc, "code", code);
+	Py_DECREF(code);
+	if (err != 0)
+		return (-1);
+
+	name = PyUnicode_FromString(zfs_error_name(EZFS_EXISTS));
+	if (name == NULL)
+		return (-1);
+	err = PyObject_SetAttrString(exc, "name", name);
+	Py_DECREF(name);
+	if (err != 0)
+		return (-1);
+
+	return (PyObject_SetAttrString(exc, "snapshots", snapshots));
+}
+
+/*
+ * lzc_rollback_to() returns EEXIST when the requested snapshot is not the most
+ * recent one because newer snapshots or bookmarks still exist. Enumerate those
+ * conflicting snapshots and bookmarks (the ones "zfs rollback -r" would
+ * force-delete) and raise MoreRecentSnapshotsExist with the resulting list.
+ *
+ * The libzfs enumeration issues blocking ioctls, so it runs with the GIL
+ * released, collecting into a plain C array. The Python list and exception are
+ * built afterwards with the GIL held.
+ *
+ * Returns B_TRUE if a Python exception was set (either MoreRecentSnapshotsExist
+ * itself or an error encountered while building it). Returns B_FALSE if the
+ * conflicting snapshots could not be determined (e.g. the dataset could no
+ * longer be opened), in which case the caller should fall back to a generic
+ * error.
+ */
+static boolean_t
+raise_more_recent_snapshots(const char *resource,
+			    const char *snapfull)
+{
+	libzfs_handle_t *hdl = NULL;
+	zfs_handle_t *ds = NULL;
+	zfs_handle_t *snap = NULL;
+	rollback_conflict_t cb = { 0 };
+	PyObject *names = NULL;
+	PyObject *exc = NULL;
+	boolean_t gathered = B_FALSE;
+	boolean_t raised = B_FALSE;
+	size_t i;
+	int err = 0;
+
+	Py_BEGIN_ALLOW_THREADS
+	hdl = libzfs_init();
+	if (hdl != NULL) {
+		snap = zfs_open(hdl, snapfull, ZFS_TYPE_SNAPSHOT);
+		ds = zfs_open(hdl, resource,
+			      ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
+		if (snap != NULL && ds != NULL) {
+			cb.target_txg = zfs_prop_get_int(snap,
+							 ZFS_PROP_CREATETXG);
+
+			cb.is_bookmark = B_FALSE;
+			err = zfs_iter_snapshots(ds, B_FALSE,
+						 rollback_conflict_cb, &cb,
+						 cb.target_txg, 0);
+			if (err == 0) {
+				cb.is_bookmark = B_TRUE;
+				err = zfs_iter_bookmarks(ds,
+							 rollback_conflict_cb,
+							 &cb);
+			}
+
+			if (err == 0 && !cb.alloc_error) {
+				qsort(cb.entries, cb.count,
+				      sizeof(*cb.entries), rollback_entry_cmp);
+				gathered = B_TRUE;
+			}
+		}
+	}
+	if (snap != NULL)
+		zfs_close(snap);
+	if (ds != NULL)
+		zfs_close(ds);
+	if (hdl != NULL)
+		libzfs_fini(hdl);
+	Py_END_ALLOW_THREADS
+
+	/* Could not determine the conflicting set; let the caller fall back. */
+	if (!gathered) {
+		free(cb.entries);
+		return (B_FALSE);
+	}
+
+	names = PyList_New(0);
+	if (names == NULL) {
+		raised = B_TRUE;  // MemoryError already set
+		goto out;
+	}
+
+	for (i = 0; i < cb.count; i++) {
+		PyObject *name = PyUnicode_FromString(cb.entries[i].name);
+		if (name == NULL) {
+			raised = B_TRUE;
+			goto out;
+		}
+		if (PyList_Append(names, name) != 0) {
+			Py_DECREF(name);
+			raised = B_TRUE;
+			goto out;
+		}
+		Py_DECREF(name);
+	}
+
+	/*
+	 * Build it as a normal ZFSException: a human-readable message argument
+	 * plus the conventional `code`/`name` attributes set to EZFS_EXISTS, and
+	 * the conflicting entries exposed via `snapshots`.
+	 */
+	exc = PyObject_CallFunction(get_more_recent_snapshots_exc_type(), "s",
+	    "more recent snapshots or bookmarks exist");
+	if (exc == NULL) {
+		raised = B_TRUE;  // python error already set
+		goto out;
+	}
+
+	raised = B_TRUE;
+	if (rollback_set_exc_attrs(exc, names) == 0)
+		PyErr_SetObject((PyObject *)Py_TYPE(exc), exc);
+
+	Py_DECREF(exc);
+
+out:
+	free(cb.entries);
+	Py_XDECREF(names);
+	return (raised);
+}
+
 PyDoc_STRVAR(py_zfs_core_rollback__doc__,
 "rollback(*, resource_name, snapshot_name=None) -> str\n"
 "------------------------------------------------------------------\n\n"
@@ -1533,9 +1759,12 @@ PyDoc_STRVAR(py_zfs_core_rollback__doc__,
 "FileNotFoundError:\n"
 "    Target resource or snapshot does not exist.\n"
 "\n"
-"FileExistsError:\n"
+"MoreRecentSnapshotsExist:\n"
 "    Rollback could not take place because the specified `snapshot_name` is\n"
-"    not the most recent snapshot.\n"
+"    not the most recent snapshot. The exception's `snapshots` attribute is a\n"
+"    list of the snapshots and bookmarks that are more recent than the target\n"
+"    and which therefore block the rollback. This is a subclass of\n"
+"    ZFSException with `code` set to ZFSError.EZFS_EXISTS.\n"
 "\n"
 "PermissionError:\n"
 "    User lacks permission to roll back dataset.\n"
@@ -1596,6 +1825,18 @@ static PyObject *py_lzc_rollback(PyObject *self,
 		 */
 		PyObject *errstr = NULL;
 		PyObject *etuple = NULL;
+
+		/*
+		 * lzc_rollback_to() reports EEXIST when the requested snapshot
+		 * is not the most recent one. Replace the bare OSError with
+		 * MoreRecentSnapshotsExist, which carries the list of snapshots
+		 * and bookmarks that block the rollback. snapret holds the fully
+		 * qualified target snapshot name in this (csnap != NULL) path.
+		 */
+		if (err == EEXIST && csnap != NULL &&
+		    raise_more_recent_snapshots(crsrc, snapret)) {
+			return NULL;
+		}
 
 		errstr = PyUnicode_FromFormat("Failed to rollback %s to %s: %s",
 		    crsrc, csnap ? csnap : "<LATEST>", strerror(err));

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -607,6 +607,7 @@ PyMODINIT_FUNC
 PyInit_truenas_pylibzfs(void)
 {
 	PyObject *zfs_exc;
+	PyObject *mre_exc;
 	PyObject *constants = NULL;
 	PyObject *libzfs_types = NULL;
 	PyObject *lzc = NULL;
@@ -639,17 +640,27 @@ PyInit_truenas_pylibzfs(void)
 		return NULL;
 	}
 
-	lzc = py_setup_lzc_module(mpylibzfs);
-	err = PyModule_AddObjectRef(mpylibzfs, "lzc", lzc);
-	Py_XDECREF(lzc);
+	zfs_exc = setup_zfs_exception();
+	err = PyModule_AddObjectRef(mpylibzfs, "ZFSException", zfs_exc);
+	Py_XDECREF(zfs_exc);
 	if (err) {
 		Py_DECREF(mpylibzfs);
 		return NULL;
 	}
 
-	zfs_exc = setup_zfs_exception();
-	err = PyModule_AddObjectRef(mpylibzfs, "ZFSException", zfs_exc);
-	Py_XDECREF(zfs_exc);
+	/* MoreRecentSnapshotsExist derives from ZFSException (set up above). */
+	mre_exc = setup_more_recent_snapshots_exception();
+	err = PyModule_AddObjectRef(mpylibzfs, "MoreRecentSnapshotsExist",
+				    mre_exc);
+	Py_XDECREF(mre_exc);
+	if (err) {
+		Py_DECREF(mpylibzfs);
+		return NULL;
+	}
+
+	lzc = py_setup_lzc_module(mpylibzfs);
+	err = PyModule_AddObjectRef(mpylibzfs, "lzc", lzc);
+	Py_XDECREF(lzc);
 	if (err) {
 		Py_DECREF(mpylibzfs);
 		return NULL;

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -227,6 +227,8 @@ extern const char *zfs_error_name(zfs_error_t error);
 extern void py_get_zfs_error(libzfs_handle_t *lz, py_zfs_error_t *out);
 
 extern PyObject *setup_zfs_exception(void);
+extern PyObject *setup_more_recent_snapshots_exception(void);
+extern PyObject *get_more_recent_snapshots_exc_type(void);
 
 /*
  * @brief set a ZFSError exception based on given parameters

--- a/stubs/__init__.pyi
+++ b/stubs/__init__.pyi
@@ -26,6 +26,9 @@ class ZFSException(RuntimeError):
     location: ClassVar[str] = ...
     name: ClassVar[str] = ...
 
+class MoreRecentSnapshotsExist(ZFSException):
+    snapshots: list[str]
+
 
 def create_vdev_spec(
     *,

--- a/tests/test_lzc_rollback.py
+++ b/tests/test_lzc_rollback.py
@@ -2,7 +2,8 @@
 Tests for lzc.rollback():
   - rollback to most recent snapshot returns snap name (str)
   - rollback with explicit snapshot_name
-  - rollback to non-most-recent raises FileExistsError
+  - rollback to non-most-recent raises MoreRecentSnapshotsExist
+    (a subclass of ZFSException) carrying the conflicting snapshots
   - rollback on nonexistent resource raises
   - keyword-only enforcement
 """
@@ -89,9 +90,46 @@ def test_rollback_with_named_snapshot(dataset_with_two_snaps):
 
 def test_rollback_to_non_recent_raises(dataset_with_two_snaps):
     lz, ds_name, snap1, snap2 = dataset_with_two_snaps
-    # snap1 is not the most recent — must raise
+    # snap1 is not the most recent — must raise MoreRecentSnapshotsExist
     snap1_component = snap1.split('@')[1]
-    with pytest.raises((FileExistsError, lzc.ZFSCoreException)):
+    with pytest.raises(truenas_pylibzfs.MoreRecentSnapshotsExist) as exc_info:
+        lzc.rollback(resource_name=ds_name, snapshot_name=snap1_component)
+
+    exc = exc_info.value
+    # snap2 is more recent than snap1 and therefore blocks the rollback
+    assert snap2 in exc.snapshots
+    # it is a ZFSException carrying the EZFS_EXISTS code
+    assert isinstance(exc, truenas_pylibzfs.ZFSException)
+    assert exc.code == truenas_pylibzfs.ZFSError.EZFS_EXISTS
+
+
+def test_rollback_conflict_list_is_ordered(dataset_with_two_snaps):
+    lz, ds_name, snap1, snap2 = dataset_with_two_snaps
+    # add a third snapshot, more recent than snap2 (and snap1)
+    snap3 = f'{ds_name}@rb_snap_c'
+    lzc.create_snapshots(snapshot_names=[snap3])
+    try:
+        snap1_component = snap1.split('@')[1]
+        with pytest.raises(truenas_pylibzfs.MoreRecentSnapshotsExist) as exc_info:
+            lzc.rollback(resource_name=ds_name, snapshot_name=snap1_component)
+
+        # conflicting snapshots are returned in ascending creation order
+        assert exc_info.value.snapshots == [snap2, snap3]
+    finally:
+        try:
+            lzc.destroy_snapshots(snapshot_names=[snap3])
+        except Exception:
+            pass
+
+
+def test_more_recent_snapshots_exist_is_zfs_exception(dataset_with_two_snaps):
+    # MoreRecentSnapshotsExist belongs to the ZFS exception hierarchy, so it
+    # must be catchable as ZFSException
+    assert issubclass(truenas_pylibzfs.MoreRecentSnapshotsExist, truenas_pylibzfs.ZFSException)
+
+    lz, ds_name, snap1, snap2 = dataset_with_two_snaps
+    snap1_component = snap1.split('@')[1]
+    with pytest.raises(truenas_pylibzfs.ZFSException):
         lzc.rollback(resource_name=ds_name, snapshot_name=snap1_component)
 
 

--- a/tests/type_checks/stubtest_allowlist.txt
+++ b/tests/type_checks/stubtest_allowlist.txt
@@ -1,0 +1,9 @@
+# stubtest allowlist for truenas_pylibzfs
+#
+# Each line is a regular expression matching a fully-qualified name that
+# stubtest should not flag.
+
+# MoreRecentSnapshotsExist.snapshots is a required list[str] on every raised
+# instance; this is an instance-only attribute stubtest structurally cannot
+# verify.
+truenas_pylibzfs.MoreRecentSnapshotsExist.snapshots

--- a/tests/type_checks/test_lzc.py
+++ b/tests/type_checks/test_lzc.py
@@ -6,6 +6,7 @@ A type error here means a stub signature is broken or a caller is using the API 
 """
 from collections.abc import Iterable
 
+import truenas_pylibzfs
 from truenas_pylibzfs import lzc
 
 
@@ -168,3 +169,11 @@ def check_exception_fields(exc: lzc.ZFSCoreException) -> None:
     name: str = exc.name
     errors: tuple[object, ...] | None = exc.errors
     _ = (code, msg, name, errors)
+
+
+def check_more_recent_snapshots_exc(
+    exc: truenas_pylibzfs.MoreRecentSnapshotsExist,
+) -> None:
+    snapshots: list[str] = exc.snapshots
+    code: int = exc.code
+    _ = (snapshots, code)


### PR DESCRIPTION
Raised by lzc.rollback() when the target dataset cannot be rolled back to the requested snapshot because more recent snapshots or bookmarks exist. Exposes which specific snapshots and bookmarks exist in order to build a user-friendly error message.