### PR TITLE
NAS-141547 / 26.0.0-RC.1 / Fix `zpool_prop_table_to_dict` (by themylogin)

### DIFF
--- a/src/libzfs/py_zfs_enum.c
+++ b/src/libzfs/py_zfs_enum.c
@@ -93,8 +93,10 @@ fail:
  *
  * Member names are derived from zpool_prop_to_name() uppercased so that
  * ZPOOLProperty.FAILMODE.name.lower() == "failmode" (the struct field name).
- * INVAL (-1) is added as a special case since zpool_prop_to_name() returns
- * NULL for it.
+ * The ZPOOL_PROP_INVAL sentinel (-1) is handled explicitly as "INVAL": it must
+ * NOT be passed to zpool_prop_to_name(), which is an unchecked
+ * "return zpool_prop_table[prop].pd_name", so zpool_prop_to_name(-1) is an
+ * out-of-bounds read that can return a bogus name rather than NULL.
  */
 static
 PyObject *zpool_prop_table_to_dict(void)
@@ -111,11 +113,10 @@ PyObject *zpool_prop_table_to_dict(void)
 
 	for (i = 0; i < ARRAY_SIZE(zpool_prop_table); i++) {
 		zpool_prop_t prop = zpool_prop_table[i];
-		const char *name = zpool_prop_to_name(prop);
+		const char *name;
 		size_t j;
 
-		if (name == NULL) {
-			/* INVAL sentinel (-1) */
+		if (prop == ZPOOL_PROP_INVAL) {
 			val = PyLong_FromLong((long)prop);
 			if (val == NULL)
 				goto fail;
@@ -125,6 +126,8 @@ PyObject *zpool_prop_table_to_dict(void)
 				goto fail;
 			continue;
 		}
+
+		name = zpool_prop_to_name(prop);
 
 		for (j = 0; j < sizeof(upper_name) - 1 && name[j] != '\0'; j++)
 			upper_name[j] = toupper((unsigned char)name[j]);

--- a/tests/test_kstat_arcstats.py
+++ b/tests/test_kstat_arcstats.py
@@ -78,9 +78,9 @@ def test_arcstats_returns_ints():
 
 
 def test_arcstats_field_count():
-    """ArcStats field count must equal ARCSTATS_N_FIELDS (147)."""
+    """ArcStats field count must equal ARCSTATS_N_FIELDS (148)."""
     stats = kstat.get_arcstats()
-    assert len(stats) == 147
+    assert len(stats) == 148
 
 
 def test_arcstats_successive_calls_are_independent():


### PR DESCRIPTION
CI fails with
```
error: truenas_pylibzfs.ZPOOLProperty.ROTATIONAL is not present in stub
Stub: in file /usr/lib/python3/dist-packages/truenas_pylibzfs/__init__.pyi
MISSING
Runtime:
<ZPOOLProperty.ROTATIONAL: -1>
```

It was the ZPOOL_PROP_INVAL sentinel (-1) mislabeled. The enum-builder detected the sentinel by checking `zpool_prop_to_name(prop) == NULL`. But libzfs implements that function as a bare, unchecked:
```
const char *zpool_prop_to_name(zpool_prop_t prop) {
    return (zpool_prop_table[prop].pd_name);
}
```
So `zpool_prop_to_name(-1)` reads `zpool_prop_table[-1]` — out of bounds, undefined behavior. In my standalone test binary that memory read as NULL; inside the real libzfs.so it reads into the adjacent vdev-property table and returns the pointer to "rotational" (a real vdev property). That bogus name got uppercased into the ROTATIONAL member with the sentinel's -1 value. So: all real pool props are positive; this one was a garbage label on the invalid sentinel.

Original PR: https://github.com/truenas/truenas_pylibzfs/pull/258
